### PR TITLE
:sparkles: Add Renderer class in preparation for config file serving

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.2.0
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-go-golems/glazed v0.2.81
+	github.com/go-go-golems/glazed v0.2.82
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/glazed v0.2.81 h1:fIjARbg+jgEa3gapZZgKXxljRpFzMKsEQeOuKCKNChc=
-github.com/go-go-golems/glazed v0.2.81/go.mod h1:xYq7afZXGsPj6jS0ZyzCLTENZlIl7vGush2vCSufnNs=
+github.com/go-go-golems/glazed v0.2.82 h1:kPfRu+kGAKvy0u1ot45BBnkk7coF/DO2p61T5u/CQ9w=
+github.com/go-go-golems/glazed v0.2.82/go.mod h1:wlKdrmjongDOf2gqPVd8OwPVp50PVgWyv65mhxcEkP0=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/parka.go
+++ b/pkg/parka.go
@@ -257,7 +257,7 @@ func (s *Server) LookupTemplate(name ...string) (*template.Template, error) {
 	return t, nil
 }
 
-// serverMarkdownTemplatePage is an internal helper function to look up a markdown or HTML file
+// ServeMarkdownTemplatePage is an internal helper function to look up a markdown or HTML file
 // and serve it.
 //
 // It first looks for a markdown file or template called either page.md or page.tmpl.md,
@@ -268,7 +268,7 @@ func (s *Server) LookupTemplate(name ...string) (*template.Template, error) {
 // If no markdown file or template is found, it will look for a HTML file or template called
 // either page.html or page.tmpl.html and serve it as a template, passing it the given data.
 // page.html is served as a plain HTML file, while page.tmpl.html is served as a template.
-func (s *Server) serveMarkdownTemplatePage(c *gin.Context, page string, data interface{}) {
+func (s *Server) ServeMarkdownTemplatePage(c *gin.Context, page string, data interface{}) {
 	t, err := s.LookupTemplate(page+".tmpl.md", page+".md")
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Error looking up template")
@@ -323,7 +323,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	s.Router.GET("/", func(c *gin.Context) {
-		s.serveMarkdownTemplatePage(c, "index", nil)
+		s.ServeMarkdownTemplatePage(c, "index", nil)
 	})
 
 	// match all remaining paths to the templates
@@ -332,7 +332,7 @@ func (s *Server) Run(ctx context.Context) error {
 			rawPath := c.Request.URL.Path
 			if len(rawPath) > 0 && rawPath[0] == '/' {
 				trimmedPath := rawPath[1:]
-				s.serveMarkdownTemplatePage(c, trimmedPath, nil)
+				s.ServeMarkdownTemplatePage(c, trimmedPath, nil)
 				return
 			}
 			c.Next()

--- a/pkg/parka.go
+++ b/pkg/parka.go
@@ -241,10 +241,11 @@ func (s *Server) Run(ctx context.Context) error {
 		s.Router.StaticFS(path.urlPath, path.fs)
 	}
 
-	s.Router.GET("/", s.DefaultRenderer.HandleWithTemplate("index", nil))
-
 	// match all remaining paths to the templates
-	s.Router.Use(s.DefaultRenderer.Handle(nil))
+	if s.DefaultRenderer != nil {
+		s.Router.GET("/", s.DefaultRenderer.HandleWithTemplate("index", nil))
+		s.Router.Use(s.DefaultRenderer.Handle(nil))
+	}
 
 	addr := fmt.Sprintf("%s:%d", s.Address, s.Port)
 

--- a/pkg/parka.go
+++ b/pkg/parka.go
@@ -7,9 +7,7 @@ import (
 	"github.com/gin-gonic/contrib/gzip"
 	"github.com/gin-gonic/gin"
 	"github.com/go-go-golems/parka/pkg/render"
-	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
-	"html/template"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -67,42 +65,13 @@ type Server struct {
 	Router *gin.Engine
 
 	StaticPaths     []StaticPath
-	TemplateLookups []render.TemplateLookup
+	DefaultRenderer *render.Renderer
 
 	Port    uint16
 	Address string
 }
 
 type ServerOption = func(*Server) error
-
-// WithPrependTemplateLookups will prepend the given template lookups to the list of lookups,
-// ensuring that they will be found before whatever templates might already be in the list.
-func WithPrependTemplateLookups(lookups ...render.TemplateLookup) ServerOption {
-	return func(s *Server) error {
-		// prepend lookups to the list
-		s.TemplateLookups = append(lookups, s.TemplateLookups...)
-		return nil
-	}
-}
-
-// WithAppendTemplateLookups will append the given template lookups to the list of lookups,
-// but they will be found after whatever templates might already be in the list. This is great
-// for providing fallback templates.
-func WithAppendTemplateLookups(lookups ...render.TemplateLookup) ServerOption {
-	return func(s *Server) error {
-		// append lookups to the list
-		s.TemplateLookups = append(s.TemplateLookups, lookups...)
-		return nil
-	}
-}
-
-// WithReplaceTemplateLookups will replace any existing template lookups with the given ones.
-func WithReplaceTemplateLookups(lookups ...render.TemplateLookup) ServerOption {
-	return func(s *Server) error {
-		s.TemplateLookups = lookups
-		return nil
-	}
-}
 
 // WithStaticPaths will add the given static paths to the list of static paths.
 // If a path with the same URL path already exists, it will be replaced.
@@ -146,14 +115,32 @@ func WithFailOption(err error) ServerOption {
 	}
 }
 
-func WithDefaultParkaLookup() ServerOption {
+func WithDefaultRenderer(r *render.Renderer) ServerOption {
+	return func(s *Server) error {
+		s.DefaultRenderer = r
+		return nil
+	}
+}
+
+func WithDefaultParkaLookup(options ...render.RendererOption) ServerOption {
 	// this should be overloaded too
 	parkaLookup, err := render.LookupTemplateFromFS(templateFS, "web/src/templates", "**/*.tmpl.*")
 	if err != nil {
 		return WithFailOption(err)
 	}
 
-	return WithAppendTemplateLookups(parkaLookup)
+	options_ := []render.RendererOption{
+		render.WithAppendTemplateLookups(parkaLookup),
+		render.WithMarkdownBaseTemplateName("base.tmpl.html"),
+	}
+	options_ = append(options_, options...)
+
+	renderer, err := render.NewRenderer(options_...)
+	if err != nil {
+		return WithFailOption(err)
+	}
+
+	return WithDefaultRenderer(renderer)
 }
 
 func WithDefaultParkaStaticPaths() ServerOption {
@@ -177,9 +164,8 @@ func NewServer(options ...ServerOption) (*Server, error) {
 	router := gin.Default()
 
 	s := &Server{
-		Router:          router,
-		StaticPaths:     []StaticPath{},
-		TemplateLookups: []render.TemplateLookup{},
+		Router:      router,
+		StaticPaths: []StaticPath{},
 	}
 
 	for _, option := range options {
@@ -238,105 +224,16 @@ func (e *EmbedFileSystem) Exists(prefix string, path string) bool {
 	return true
 }
 
-// LookupTemplate will iterate through the template lookups until it finds one of the
-// templates given in name.
-func (s *Server) LookupTemplate(name ...string) (*template.Template, error) {
-	var t *template.Template
-
-	for _, lookup := range s.TemplateLookups {
-		t, err := lookup(name...)
-		if err != nil {
-			log.Debug().Err(err).Strs("name", name).Msg("failed to lookup template, skipping")
-
-		}
-		if err == nil {
-			return t, nil
-		}
-	}
-
-	return t, nil
-}
-
-// ServeMarkdownTemplatePage is an internal helper function to look up a markdown or HTML file
-// and serve it.
-//
-// It first looks for a markdown file or template called either page.md or page.tmpl.md,
-// and render it as a template, passing it the given data.
-// It will use base.tmpl.html as the base template for serving the resulting markdown HTML.
-// page.md is rendered as a plain markdown file, while page.tmpl.md is rendered as a template.
-//
-// If no markdown file or template is found, it will look for a HTML file or template called
-// either page.html or page.tmpl.html and serve it as a template, passing it the given data.
-// page.html is served as a plain HTML file, while page.tmpl.html is served as a template.
-func (s *Server) ServeMarkdownTemplatePage(c *gin.Context, page string, data interface{}) {
-	t, err := s.LookupTemplate(page+".tmpl.md", page+".md")
-	if err != nil {
-		c.String(http.StatusInternalServerError, "Error looking up template")
-		return
-	}
-
-	if t != nil {
-		markdown, err := render.RenderMarkdownTemplateToHTML(t, nil)
-		if err != nil {
-			c.String(http.StatusInternalServerError, "Error rendering markdown")
-			return
-		}
-
-		baseTemplate, err := s.LookupTemplate("base.tmpl.html")
-		if err != nil {
-			c.String(http.StatusInternalServerError, "Error rendering template")
-			return
-		}
-
-		err = baseTemplate.Execute(
-			c.Writer,
-			map[string]interface{}{
-				"markdown": template.HTML(markdown),
-			})
-		if err != nil {
-			c.String(http.StatusInternalServerError, "Error rendering template")
-			return
-		}
-	} else {
-		t, err = s.LookupTemplate(page+".tmpl.html", page+".html")
-		if err != nil {
-			c.String(http.StatusInternalServerError, "Error rendering template")
-			return
-		}
-		if t == nil {
-			c.String(http.StatusInternalServerError, "Error rendering template")
-			return
-		}
-
-		err := t.Execute(c.Writer, data)
-		if err != nil {
-			c.String(http.StatusInternalServerError, "Error rendering template")
-			return
-		}
-	}
-}
-
 // Run will start the server and listen on the given address and port.
 func (s *Server) Run(ctx context.Context) error {
 	for _, path := range s.StaticPaths {
 		s.Router.StaticFS(path.urlPath, path.fs)
 	}
 
-	s.Router.GET("/", func(c *gin.Context) {
-		s.ServeMarkdownTemplatePage(c, "index", nil)
-	})
+	s.Router.GET("/", s.DefaultRenderer.HandleWithTemplate("index", nil))
 
 	// match all remaining paths to the templates
-	s.Router.Use(
-		func(c *gin.Context) {
-			rawPath := c.Request.URL.Path
-			if len(rawPath) > 0 && rawPath[0] == '/' {
-				trimmedPath := rawPath[1:]
-				s.ServeMarkdownTemplatePage(c, trimmedPath, nil)
-				return
-			}
-			c.Next()
-		})
+	s.Router.Use(s.DefaultRenderer.Handle(nil))
 
 	addr := fmt.Sprintf("%s:%d", s.Address, s.Port)
 

--- a/pkg/parka.go
+++ b/pkg/parka.go
@@ -122,16 +122,23 @@ func WithDefaultRenderer(r *render.Renderer) ServerOption {
 	}
 }
 
-func WithDefaultParkaLookup(options ...render.RendererOption) ServerOption {
+func GetDefaultParkaRendererOptions() ([]render.RendererOption, error) {
 	// this should be overloaded too
 	parkaLookup, err := render.LookupTemplateFromFS(templateFS, "web/src/templates", "**/*.tmpl.*")
 	if err != nil {
-		return WithFailOption(err)
+		return nil, err
 	}
 
-	options_ := []render.RendererOption{
+	return []render.RendererOption{
 		render.WithAppendTemplateLookups(parkaLookup),
 		render.WithMarkdownBaseTemplateName("base.tmpl.html"),
+	}, nil
+}
+
+func WithDefaultParkaLookup(options ...render.RendererOption) ServerOption {
+	options_, err := GetDefaultParkaRendererOptions()
+	if err != nil {
+		return WithFailOption(err)
 	}
 	options_ = append(options_, options...)
 
@@ -143,9 +150,13 @@ func WithDefaultParkaLookup(options ...render.RendererOption) ServerOption {
 	return WithDefaultRenderer(renderer)
 }
 
+func GetParkaStaticFS() http.FileSystem {
+	return NewEmbedFileSystem(distFS, "web/dist")
+}
+
 func WithDefaultParkaStaticPaths() ServerOption {
 	return WithStaticPaths(
-		NewStaticPath(NewEmbedFileSystem(distFS, "web/dist"), "/dist"),
+		NewStaticPath(GetParkaStaticFS(), "/dist"),
 	)
 }
 

--- a/pkg/render/layout/layout.go
+++ b/pkg/render/layout/layout.go
@@ -6,6 +6,9 @@ import (
 	"github.com/go-go-golems/parka/pkg/glazed"
 )
 
+// This section groups all the functionality related to laying out forms for input parameters
+// for commands.
+
 // Layout might look at first similar to glazed_layout.Layout, but it is actually
 // the parsed and computed version used to render an HTML form.
 type Layout struct {

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -1,0 +1,237 @@
+package render
+
+import (
+	"context"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"html/template"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Renderer is a struct that is able to lookup a page name and render it.
+// It can handle a variety of formats:
+// - static HTML
+// - static markdown
+// - templated HTML
+// - templated markdown
+// - base HTML template to render markdown into
+// - index page templates
+//
+// It is an early replacement for what used to be the templateLookup approach in parka.Server.
+//
+// # NOTE(manuel, 2023-05-26) Some notes on the implementation rationale
+//
+// Driven by the needs for richer handling of templates mixing commands and content when building
+// reports pages with sqleton, the templateLookup approach of server, which was confusing from the start,
+// was breaking down.
+//
+// In order to more easily to configure the reports page, which would expose different command repositories
+// with manually overloaded rendering templates (datatables.tmpl.html) as well as static content (index page,
+// documentation pages), I refactored the haphazard templatelookup concept to be configured from a config file
+// and split it into different "modules" that could be "mounted" under different paths:
+// - static file
+// - static dir
+// - single command
+// - command dir
+// - template file
+// - template dir
+//
+// It is while implementing the template dir that I realized that a more generic "render paths based on configured templates
+// directories and data" as a common building block. In a way it is what I was originally searching for with the template
+// lookups pattern, but I mixed it with the concerns of serving files in parka, instead of just focusing on "render pages".
+type Renderer struct {
+	Data            map[string]interface{}
+	TemplateLookups []TemplateLookup
+
+	// MarkdownBaseTemplateName is used to wrap markdown that was rendered into HTML into a top-level page
+	// NOTE(manuel, 2023-05-26) Maybe this should be a templateLookup that always returns the same template?
+	MarkdownBaseTemplateName string
+}
+
+type RendererOption func(r *Renderer) error
+
+// WithReplaceData will replace the data the renderer uses to render out templates with the passed in data.
+func WithReplaceData(data map[string]interface{}) RendererOption {
+	return func(r *Renderer) error {
+		r.Data = data
+		return nil
+	}
+}
+
+// WithMergeData will merge the given data into the renderer's data.
+func WithMergeData(data map[string]interface{}) RendererOption {
+	return func(r *Renderer) error {
+		for k, v := range data {
+			r.Data[k] = v
+		}
+		return nil
+	}
+}
+
+// WithMarkdownBaseTemplateName will set the name of the template to use as the base template when rendering
+// the HTML coming out of markdown rendering into HTML.
+func WithMarkdownBaseTemplateName(name string) RendererOption {
+	return func(r *Renderer) error {
+		r.MarkdownBaseTemplateName = name
+		return nil
+	}
+}
+
+// WithPrependTemplateLookups will prepend the given template lookups to the list of lookups,
+// ensuring that they will be found before whatever templates might already be in the list.
+func WithPrependTemplateLookups(lookups ...TemplateLookup) RendererOption {
+	return func(s *Renderer) error {
+		// prepend lookups to the list
+		s.TemplateLookups = append(lookups, s.TemplateLookups...)
+		return nil
+	}
+}
+
+// WithAppendTemplateLookups will append the given template lookups to the list of lookups,
+// but they will be found after whatever templates might already be in the list. This is great
+// for providing fallback templates.
+func WithAppendTemplateLookups(lookups ...TemplateLookup) RendererOption {
+	return func(s *Renderer) error {
+		// append lookups to the list
+		s.TemplateLookups = append(s.TemplateLookups, lookups...)
+		return nil
+	}
+}
+
+// WithReplaceTemplateLookups will replace any existing template lookups with the given ones.
+func WithReplaceTemplateLookups(lookups ...TemplateLookup) RendererOption {
+	return func(s *Renderer) error {
+		s.TemplateLookups = lookups
+		return nil
+	}
+}
+
+func NewRenderer(opts ...RendererOption) (*Renderer, error) {
+	r := &Renderer{}
+
+	for _, opt := range opts {
+		err := opt(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return r, nil
+}
+
+// LookupTemplate will iterate through the template lookups until it finds one of the
+// templates given in name.
+func (r *Renderer) LookupTemplate(name ...string) (*template.Template, error) {
+	var t *template.Template
+
+	for _, lookup := range r.TemplateLookups {
+		t, err := lookup(name...)
+		if err != nil {
+			log.Debug().Err(err).Strs("name", name).Msg("failed to lookup template, skipping")
+
+		}
+		if err == nil {
+			return t, nil
+		}
+	}
+
+	return t, nil
+
+}
+
+// Render a given page with the given data.
+//
+// It first looks for a markdown file or template called either page.md or page.tmpl.md,
+// and render it as a template, passing it the given data.
+// It will use base.tmpl.html as the base template for serving the resulting markdown HTML.
+// page.md is rendered as a plain markdown file, while page.tmpl.md is rendered as a template.
+//
+// If no markdown file or template is found, it will look for a HTML file or template called
+// either page.html or page.tmpl.html and serve it as a template, passing it the given data.
+// page.html is served as a plain HTML file, while page.tmpl.html is served as a template.
+func (r *Renderer) Render(ctx context.Context, w io.Writer, page string, data map[string]interface{}) error {
+	// first, merge the data we want to pass to the templates, with the data passed in overridding
+	// the data in the renderer
+	data_ := map[string]interface{}{}
+	for k, v := range r.Data {
+		data_[k] = v
+	}
+	for k, v := range data {
+		data_[k] = v
+	}
+
+	// TODO(manuel, 2023-05-26) Don't render plain files as templates
+	// See https://github.com/go-go-golems/parka/issues/47
+	t, err := r.LookupTemplate(page+".tmpl.md", page+".md")
+	if err != nil {
+		return errors.Wrap(err, "error looking up template")
+	}
+
+	if t != nil {
+		markdown, err := RenderMarkdownTemplateToHTML(t, nil)
+		if err != nil {
+			return errors.Wrap(err, "error rendering markdown")
+		}
+
+		baseTemplate, err := r.LookupTemplate(r.MarkdownBaseTemplateName)
+		if err != nil {
+			return errors.Wrap(err, "error looking up base template")
+		}
+
+		err = baseTemplate.Execute(
+			w,
+			map[string]interface{}{
+				"markdown": template.HTML(markdown),
+			})
+		if err != nil {
+			return errors.Wrap(err, "error executing base template")
+		}
+	} else {
+		t, err = r.LookupTemplate(page+".tmpl.html", page+".html")
+		if err != nil {
+			return errors.Wrap(err, "error looking up template")
+		}
+		if t == nil {
+			return errors.New("no template found")
+		}
+
+		err := t.Execute(w, data)
+		if err != nil {
+			return errors.Wrap(err, "error executing template")
+		}
+	}
+	return nil
+}
+
+func (r *Renderer) HandleWithTemplate(templateName string, data map[string]interface{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		err := r.Render(c, c.Writer, templateName, data)
+		if err != nil {
+			_ = c.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+	}
+}
+
+func (r *Renderer) Handle(data map[string]interface{}) gin.HandlerFunc {
+	return r.HandleWithTrimPrefix("", data)
+}
+
+func (r *Renderer) HandleWithTrimPrefix(prefix string, data map[string]interface{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawPath := c.Request.URL.Path
+		if len(rawPath) > 0 && rawPath[0] == '/' {
+			trimmedPath := rawPath[1:]
+			trimmedPath = strings.TrimPrefix(trimmedPath, prefix)
+			err := r.Render(c, c.Writer, trimmedPath, data)
+			if err != nil {
+				_ = c.AbortWithError(http.StatusInternalServerError, err)
+				return
+			}
+		}
+		c.Next()
+	}
+}


### PR DESCRIPTION
See also https://github.com/go-go-golems/sqleton/issues/160

This consolidates the template lookup and rendering functionality into its own class (instead of Server)
as a preparatory step for handling sqleton serve's config file handling, and ultimately a nicer parka serving
framework that can deal with any kind of glazed commands.

- :art: Rename handler funcs to make their use and side effects a bit clearer
- :art: Make serveMarkdownTemplatePage public to use in sqleton serve
- :tractor: Move StartFormatIntoChannel into glazed
- :sparkles: Add Renderer to render templates from path
- :art: Add helper methods to more easily access the internal defaults of parka
- :ambulance: Properly handle multiple (or no default) renderers
- :arrow_up: Bump glazed
