### PR TITLE
:ambulance: Fix broken template directories

### DIFF
--- a/pkg/handlers/template-dir/template-dir.go
+++ b/pkg/handlers/template-dir/template-dir.go
@@ -78,19 +78,25 @@ func WithLocalDirectory(localPath string) TemplateDirHandlerOption {
 	}
 }
 
-func NewTemplateDirHandler(options ...TemplateDirHandlerOption) *TemplateDirHandler {
+func NewTemplateDirHandler(options ...TemplateDirHandlerOption) (*TemplateDirHandler, error) {
 	handler := &TemplateDirHandler{}
 	for _, option := range options {
-		option(handler)
+		err := option(handler)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return handler
+	return handler, nil
 }
 
 func NewTemplateDirHandlerFromConfig(td *config.TemplateDir, options ...TemplateDirHandlerOption) (*TemplateDirHandler, error) {
 	handler := &TemplateDirHandler{
 		IndexTemplateName: td.IndexTemplateName,
 	}
-	WithLocalDirectory(td.LocalDirectory)(handler)
+	err := WithLocalDirectory(td.LocalDirectory)(handler)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, option := range options {
 		err := option(handler)
@@ -109,7 +115,7 @@ func NewTemplateDirHandlerFromConfig(td *config.TemplateDir, options ...Template
 		),
 		render.WithAlwaysReload(handler.alwaysReload),
 	)
-	err := templateLookup.Reload()
+	err = templateLookup.Reload()
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to load local template: %w", err)

--- a/pkg/handlers/template-dir/template-dir.go
+++ b/pkg/handlers/template-dir/template-dir.go
@@ -50,10 +50,14 @@ func WithLocalDirectory(localPath string) TemplateDirHandlerOption {
 	return func(handler *TemplateDirHandler) {
 		if localPath != "" {
 			if localPath[0] == '/' {
-				handler.fs = os.DirFS(localPath)
+				handler.fs = os.DirFS("/")
 			} else {
-				handler.fs = os.DirFS(localPath)
+				handler.fs = os.DirFS(".")
 			}
+			// We strip the / prefix because once the FS is /, we need to match for "relative" paths within the FS.
+			// We can't just simplify the whole thing to be os.DirFS(localPath) because we also need to support
+			// embed.FS where we can't do the same path shenanigans, since the embed.FS files reflect the directory
+			// from which they were included, which we need to strip at runtime.
 			handler.LocalDirectory = strings.TrimPrefix(localPath, "/")
 		}
 	}

--- a/pkg/render/datatables/datatables.go
+++ b/pkg/render/datatables/datatables.go
@@ -183,14 +183,14 @@ func (d *DataTablesOutputFormatter) Output(ctx context.Context, w io.Writer) err
 		dt.HTMLStream = formatters.StartFormatIntoChannel[template.HTML](ctx, d.OutputFormatter)
 	}
 
-	if d.OutputFormatter.Table != nil {
-		dt.Columns = d.OutputFormatter.Table.Columns
-	}
-
 	// TODO(manuel, 2023-06-20) We need to properly pass the columns here, which can't be set upstream
 	// since we already pass in the JSStream here and we keep it, I think we are better off cloning the
 	// DataTables struct, or even separating it out to make d.dataTablesData immutable and just contain the
 	// toplevel config.
+	if d.OutputFormatter.Table != nil {
+		dt.Columns = d.OutputFormatter.Table.Columns
+	}
+
 	err := d.HTMLTemplateOutputFormatter.Template.Execute(w, dt)
 
 	if err != nil {


### PR DESCRIPTION
The lookup on template directories was not handling absolute directories correctly.
Not sure how this ever worked (when I tested with a config file).

- :ambulance: Fix lookup of template directories for absolute and relative paths
- :ambulance: Fix lookup of template directories for absolute and relative paths
- :ambulance: Set status code 200 when a template is rendered
- :art: :pencil: Reorder comment for legibility
- :art: Fix linting errors
