### PR TITLE
:sparkles: Add default options to config file

### DIFF
--- a/pkg/handlers/config-file.go
+++ b/pkg/handlers/config-file.go
@@ -137,6 +137,22 @@ func (cfh *ConfigFileHandler) Serve(server_ *server.Server) error {
 		}
 	}
 
+	if *cfh.Config.Defaults.Renderer.UseDefaultParkaRenderer {
+		parkaDefaultRendererOptions, err := server.GetDefaultParkaRendererOptions()
+		if err != nil {
+			return err
+		}
+
+		// prepend the renderer options to the list of options
+		// honestly this setting should actually be a setting for each route as well
+		cfh.TemplateDirectoryOptions = append([]template_dir.TemplateDirHandlerOption{
+			template_dir.WithAppendRendererOptions(parkaDefaultRendererOptions...),
+		}, cfh.TemplateDirectoryOptions...)
+		cfh.TemplateOptions = append([]template.TemplateHandlerOption{
+			template.WithAppendRendererOptions(parkaDefaultRendererOptions...),
+		}, cfh.TemplateOptions...)
+	}
+
 	for _, route := range cfh.Config.Routes {
 		if route.CommandDirectory != nil {
 			// TODO(manuel, 2023-05-31) We must pass in the RepositoryConstructor here,

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -78,14 +78,21 @@ func expandPath(path string) string {
 // TODO(manuel, 2023-06-20) We should probably allow for environment values to be passed as data as well
 
 type CommandDir struct {
-	Repositories               []string          `yaml:"repositories"`
-	IncludeDefaultRepositories bool              `yaml:"includeDefaultRepositories"`
-	TemplateDirectory          string            `yaml:"templateDirectory,omitempty"`
-	TemplateName               string            `yaml:"templateName,omitempty"`
-	IndexTemplateName          string            `yaml:"indexTemplateName,omitempty"`
-	AdditionalData             map[string]string `yaml:"additionalData,omitempty"`
-	Defaults                   *LayerParams      `yaml:"defaults,omitempty"`
-	Overrides                  *LayerParams      `yaml:"overrides,omitempty"`
+	Repositories               []string `yaml:"repositories"`
+	IncludeDefaultRepositories bool     `yaml:"includeDefaultRepositories"`
+
+	// TODO(manuel, 2023-06-21) Unify support to override the default renderer for individual routes
+	// See https://github.com/go-go-golems/parka/issues/55
+	// We should probably make it possible to pass multiple template directories for the renderer options
+	// so that we can bundle the embedded templates and override them with external ones, as well
+	// as merge together multiple datatables renderers.
+	TemplateDirectory string `yaml:"templateDirectory,omitempty"`
+	TemplateName      string `yaml:"templateName,omitempty"`
+	IndexTemplateName string `yaml:"indexTemplateName,omitempty"`
+
+	AdditionalData map[string]string `yaml:"additionalData,omitempty"`
+	Defaults       *LayerParams      `yaml:"defaults,omitempty"`
+	Overrides      *LayerParams      `yaml:"overrides,omitempty"`
 }
 
 func (c *CommandDir) ExpandPaths() error {
@@ -145,10 +152,9 @@ func (s *StaticFile) ExpandPaths() error {
 // Markdown files are renderer using the given MarkdownBaseTemplateName, which will be
 // looked up in the TemplateDir itself, or using the default renderer if empty.
 type TemplateDir struct {
-	LocalDirectory           string                 `yaml:"localDirectory"`
-	IndexTemplateName        string                 `yaml:"indexTemplateName,omitempty"`
-	MarkdownBaseTemplateName string                 `yaml:"markdownBaseTemplateName,omitempty"`
-	AdditionalData           map[string]interface{} `yaml:"additionalData,omitempty"`
+	LocalDirectory    string                 `yaml:"localDirectory"`
+	IndexTemplateName string                 `yaml:"indexTemplateName,omitempty"`
+	AdditionalData    map[string]interface{} `yaml:"additionalData,omitempty"`
 }
 
 func (t *TemplateDir) ExpandPaths() error {
@@ -161,8 +167,7 @@ type Template struct {
 	// content.
 	TemplateFile string `yaml:"templateFile"`
 	// TODO(manuel, 2023-06-20) Add the option to pass in data to the template
-	AdditionalData           map[string]interface{} `yaml:"additionalData,omitempty"`
-	MarkdownBaseTemplateName string                 `yaml:"markdownBaseTemplateName,omitempty"`
+	AdditionalData map[string]interface{} `yaml:"additionalData,omitempty"`
 }
 
 func (t *Template) ExpandPaths() error {

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -243,6 +243,15 @@ func ParseConfig(data []byte) (*Config, error) {
 		return nil, err
 	}
 
+	err = cfg.Initialize()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+func (cfg *Config) Initialize() error {
 	if cfg.Defaults == nil {
 		cfg.Defaults = &Defaults{
 			UseParkaStaticFiles: boolPtr(true),
@@ -267,44 +276,45 @@ func ParseConfig(data []byte) (*Config, error) {
 			}
 		}
 	}
+	var err error
 	for _, route := range cfg.Routes {
 		if route.CommandDirectory != nil {
 			err = route.CommandDirectory.ExpandPaths()
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if route.Command != nil {
 			err = route.Command.ExpandPaths()
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if route.Static != nil {
 			err = route.Static.ExpandPaths()
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if route.StaticFile != nil {
 			err = route.StaticFile.ExpandPaths()
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if route.Template != nil {
 			err = route.Template.ExpandPaths()
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 		if route.TemplateDirectory != nil {
 			err = route.TemplateDirectory.ExpandPaths()
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
-	return &cfg, nil
+	return nil
 }

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -222,7 +222,10 @@ type Defaults struct {
 // It renders markdown files using base.tmpl.html and uses a tailwind css stylesheet
 // which has to be served under dist/output.css.
 type DefaultRendererOptions struct {
-	UseDefaultParkaRenderer  *bool  `yaml:"useDefaultParkaRenderer,omitempty"`
+	UseDefaultParkaRenderer *bool `yaml:"useDefaultParkaRenderer,omitempty"`
+	// TODO(manuel, 2023-06-21) These two options are not implemented yet
+	// It is not so much that they are hard to implement, but rather that they are annoying to test.
+	// See: https://github.com/go-go-golems/parka/issues/56
 	TemplateDirectory        string `yaml:"templateDirectory,omitempty"`
 	MarkdownBaseTemplateName string `yaml:"markdownBaseTemplateName,omitempty"`
 }
@@ -269,10 +272,16 @@ func (cfg *Config) Initialize() error {
 				UseDefaultParkaRenderer: boolPtr(true),
 			}
 		} else {
-			if cfg.Defaults.Renderer.UseDefaultParkaRenderer == nil &&
-				cfg.Defaults.UseParkaStaticFiles != nil &&
-				*cfg.Defaults.UseParkaStaticFiles {
-				cfg.Defaults.Renderer.UseDefaultParkaRenderer = boolPtr(true)
+			if cfg.Defaults.Renderer.UseDefaultParkaRenderer == nil {
+				if cfg.Defaults.Renderer.TemplateDirectory == "" {
+					cfg.Defaults.Renderer.UseDefaultParkaRenderer = boolPtr(true)
+				} else {
+					cfg.Defaults.Renderer.UseDefaultParkaRenderer = boolPtr(false)
+				}
+			}
+
+			if cfg.Defaults.Renderer.TemplateDirectory != "" {
+				cfg.Defaults.Renderer.TemplateDirectory = expandPath(cfg.Defaults.Renderer.TemplateDirectory)
 			}
 		}
 	}

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -188,15 +188,28 @@ func (r *Renderer) Render(
 		return errors.Wrap(err, "error looking up template")
 	}
 
+	baseTemplate, err := r.LookupTemplate(r.MarkdownBaseTemplateName)
+	if err != nil {
+		return errors.Wrap(err, "error looking up base template")
+	}
+
+	if baseTemplate == nil {
+		// no base template to render the markdown to HTML, so just return the markdown
+		c.Header("Content-Type", "text/plain")
+		c.Status(http.StatusOK)
+
+		err := t.Execute(c.Writer, data)
+		if err != nil {
+			return errors.Wrap(err, "error executing template")
+		}
+
+		return nil
+	}
+
 	if t != nil {
 		markdown, err := RenderMarkdownTemplateToHTML(t, nil)
 		if err != nil {
 			return errors.Wrap(err, "error rendering markdown")
-		}
-
-		baseTemplate, err := r.LookupTemplate(r.MarkdownBaseTemplateName)
-		if err != nil {
-			return errors.Wrap(err, "error looking up base template")
 		}
 
 		c.Status(http.StatusOK)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-go-golems/parka/pkg/render"
 	utils_fs "github.com/go-go-golems/parka/pkg/utils/fs"
 	"golang.org/x/sync/errgroup"
+	"io/fs"
 	"net/http"
 )
 
@@ -128,13 +129,17 @@ func WithDefaultParkaRenderer(options ...render.RendererOption) ServerOption {
 	return WithDefaultRenderer(renderer)
 }
 
-func GetParkaStaticFS() http.FileSystem {
+func GetParkaStaticHttpFS() http.FileSystem {
 	return utils_fs.NewEmbedFileSystem(distFS, "web/dist")
+}
+
+func GetParkaStaticFS() fs.FS {
+	return distFS
 }
 
 func WithDefaultParkaStaticPaths() ServerOption {
 	return WithStaticPaths(
-		utils_fs.NewStaticPath(GetParkaStaticFS(), "/dist"),
+		utils_fs.NewStaticPath(GetParkaStaticHttpFS(), "/dist"),
 	)
 }
 

--- a/pkg/utils/fs/fs.go
+++ b/pkg/utils/fs/fs.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"io/fs"
 	"net/http"
+	"path/filepath"
 	"strings"
 )
 
@@ -48,7 +49,9 @@ func (e *EmbedFileSystem) Exists(prefix string, path string) bool {
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func(f http.File) {
+		_ = f.Close()
+	}(f)
 	return true
 }
 
@@ -83,5 +86,5 @@ func NewAddPrefixPathFS(fs fs.FS, prefix string) AddPrefixPathFS {
 }
 
 func (s AddPrefixPathFS) Open(name string) (fs.File, error) {
-	return s.fs.Open(s.prefix + name)
+	return s.fs.Open(filepath.Join(s.prefix, name))
 }


### PR DESCRIPTION
- :sparkles: Add support for defaults settings in config file for parka
- :sparkles: Add support for serving the default parka static files
- :ambulance: :art: Make path joining in prefixFS a bit more robust
- :sparkles: Add support to configure the default renderer
- :art: Add Config.Initialize() method
- :sparkles: Add support for explicit setting the default renderer options
