### PR TITLE
:sparkles: Add support for numerous commandDirectory config-file options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
 	github.com/yuin/goldmark v1.5.4
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20220924101305-151362477c87
@@ -81,7 +82,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.15.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tj/go-naturaldate v1.3.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.0
 	github.com/go-go-golems/clay v0.0.17
-	github.com/go-go-golems/glazed v0.2.83
+	github.com/go-go-golems/glazed v0.2.84
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-go-golems/clay v0.0.17 h1:lFOXpAs3AiBMu3LwUO2xvJ7JvkIVU4g2beRODyKGvTM=
 github.com/go-go-golems/clay v0.0.17/go.mod h1:2QM24Cz+xBFrnXr5h561DAQ/lxLYlnUO8EjlxiOsYk4=
-github.com/go-go-golems/glazed v0.2.83 h1:oIHaJdjtS95Qv1rD8uka5Md/UD9S9ClHXa5YMaTzjng=
-github.com/go-go-golems/glazed v0.2.83/go.mod h1:wlKdrmjongDOf2gqPVd8OwPVp50PVgWyv65mhxcEkP0=
+github.com/go-go-golems/glazed v0.2.84 h1:rZylJBh/ZrD1Hi4xWXGf5cFQAWbLK9C9FbB426ASWhU=
+github.com/go-go-golems/glazed v0.2.84/go.mod h1:wlKdrmjongDOf2gqPVd8OwPVp50PVgWyv65mhxcEkP0=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/glazed/command.go
+++ b/pkg/glazed/command.go
@@ -183,33 +183,9 @@ func NewParserCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Pa
 		}
 	}
 
-	// TODO(manuel, 2023-05-25) This is where we should handle default values provided from the config file
-	//
-	// See https://github.com/go-go-golems/sqleton/issues/161
-	//
-	// We should clearly establish a precedence scheme, something like:
-	// - alias defaults (loaded from repository)
-	// - overwritten by defaults set in code
-	// - overwritten by defaults set from config file
-	//
-	// See also https://github.com/go-go-golems/glazed/issues/139
-	//
-	// ## hack notes
-	//
-	// I think that parser handler could actually override / fill out the defaults here,
-	// since we just pass the map around. That's probably not the smart way to do it though,
-	// and would warrant revisiting.
-	//
-	// Actually, the parsers return updated ParameterDefinitions, which means that we should be
-	// able to override the defaults in those directly.
-	//
-	// ANSWER(manuel, 2023-06-22) Handling defaults and overrides from the config (and from code)
-	// is now handled by the parser.Parser. The above comments don't apply anymore.
-	var err error
-
 	return func(c *gin.Context, pc *CommandContext) error {
 		parseState := parser.NewParseStateFromCommandDescription(d)
-		err = parserHandler.Parse(c, parseState)
+		err := parserHandler.Parse(c, parseState)
 		if err != nil {
 			return err
 		}

--- a/pkg/glazed/command.go
+++ b/pkg/glazed/command.go
@@ -3,7 +3,6 @@ package glazed
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-go-golems/glazed/pkg/cmds"
-	"github.com/go-go-golems/glazed/pkg/cmds/alias"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/go-go-golems/parka/pkg/glazed/parser"
@@ -168,23 +167,8 @@ func NewCommandFormParser(cmd cmds.GlazeCommand, options ...parser.ParserOption)
 // NewParserCommandHandlerFunc creates a CommandHandlerFunc using the given parser.Parser.
 // It also first establishes a set of defaults by loading them from an alias definition.
 func NewParserCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) CommandHandlerFunc {
-	d := cmd.Description()
-
-	defaults := map[string]string{}
-
-	// check if we are an alias
-	alias_, ok := cmd.(*alias.CommandAlias)
-	if ok {
-		defaults = alias_.Flags
-		for idx, v := range alias_.Arguments {
-			if len(d.Arguments) <= idx {
-				defaults[d.Arguments[idx].Name] = v
-			}
-		}
-	}
-
 	return func(c *gin.Context, pc *CommandContext) error {
-		parseState := parser.NewParseStateFromCommandDescription(d)
+		parseState := parser.NewParseStateFromCommandDescription(cmd)
 		err := parserHandler.Parse(c, parseState)
 		if err != nil {
 			return err

--- a/pkg/glazed/command.go
+++ b/pkg/glazed/command.go
@@ -120,6 +120,8 @@ func HandlePrepopulatedParsedLayers(layers_ map[string]*layers.ParsedParameterLa
 func NewCommandQueryParser(cmd cmds.GlazeCommand, options ...parser.ParserOption) *parser.Parser {
 	d := cmd.Description()
 
+	// NOTE(manuel, 2023-06-21) We could pass the parser options here, but then we wouldn't be able to
+	// override the layer parser. Or we could pass the QueryParsers right here.
 	ph := parser.NewParser()
 	ph.Parsers = []parser.ParseStep{
 		parser.NewQueryParseStep(false),

--- a/pkg/glazed/command.go
+++ b/pkg/glazed/command.go
@@ -165,12 +165,9 @@ func NewCommandFormParser(cmd cmds.GlazeCommand, options ...parser.ParserOption)
 	return ph
 }
 
-// NewCommandHandlerFunc creates a CommandHandlerFunc using the given Parser struct.
-// This first establishes a set of defaults by loading them from an alias definition.
-//
-// When the CommandHandler is invoked, we first gather all the parameterDefinitions from the
-// cmd (fresh on every invocation, because the parsers are allowed to modify them).
-func NewCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) CommandHandlerFunc {
+// NewParserCommandHandlerFunc creates a CommandHandlerFunc using the given parser.Parser.
+// It also first establishes a set of defaults by loading them from an alias definition.
+func NewParserCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) CommandHandlerFunc {
 	d := cmd.Description()
 
 	defaults := map[string]string{}
@@ -205,6 +202,9 @@ func NewCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) 
 	//
 	// Actually, the parsers return updated ParameterDefinitions, which means that we should be
 	// able to override the defaults in those directly.
+	//
+	// ANSWER(manuel, 2023-06-22) Handling defaults and overrides from the config (and from code)
+	// is now handled by the parser.Parser. The above comments don't apply anymore.
 	var err error
 
 	return func(c *gin.Context, pc *CommandContext) error {

--- a/pkg/glazed/command.go
+++ b/pkg/glazed/command.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/alias"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/parka/pkg/glazed/parser"
 )
 
 // CommandContext keeps the context for execution of a glazed command,
@@ -116,19 +117,19 @@ func HandlePrepopulatedParsedLayers(layers_ map[string]*layers.ParsedParameterLa
 	}
 }
 
-func NewCommandQueryParser(cmd cmds.GlazeCommand, options ...ParserOption) *Parser {
+func NewCommandQueryParser(cmd cmds.GlazeCommand, options ...parser.ParserOption) *parser.Parser {
 	d := cmd.Description()
 
-	ph := NewParser()
-	ph.Parsers = []ParserFunc{
-		NewQueryParserFunc(false),
+	ph := parser.NewParser()
+	ph.Parsers = []parser.ParserFunc{
+		parser.NewQueryParserFunc(false),
 	}
 
 	// NOTE(manuel, 2023-04-16) API design: we would probably like to hide layers right here in the handler constructor
 	for _, l := range d.Layers {
 		slug := l.GetSlug()
-		ph.LayerParsersBySlug[slug] = []ParserFunc{
-			NewQueryParserFunc(false),
+		ph.LayerParsersBySlug[slug] = []parser.ParserFunc{
+			parser.NewQueryParserFunc(false),
 		}
 	}
 
@@ -139,19 +140,19 @@ func NewCommandQueryParser(cmd cmds.GlazeCommand, options ...ParserOption) *Pars
 	return ph
 }
 
-func NewCommandFormParser(cmd cmds.GlazeCommand, options ...ParserOption) *Parser {
+func NewCommandFormParser(cmd cmds.GlazeCommand, options ...parser.ParserOption) *parser.Parser {
 	d := cmd.Description()
 
-	ph := NewParser()
-	ph.Parsers = []ParserFunc{
-		NewFormParserFunc(false),
+	ph := parser.NewParser()
+	ph.Parsers = []parser.ParserFunc{
+		parser.NewFormParserFunc(false),
 	}
 
 	// NOTE(manuel, 2023-04-16) API design: we would probably like to hide layers right here in the handler constructor
 	for _, l := range d.Layers {
 		slug := l.GetSlug()
-		ph.LayerParsersBySlug[slug] = []ParserFunc{
-			NewFormParserFunc(false),
+		ph.LayerParsersBySlug[slug] = []parser.ParserFunc{
+			parser.NewFormParserFunc(false),
 		}
 	}
 
@@ -167,7 +168,7 @@ func NewCommandFormParser(cmd cmds.GlazeCommand, options ...ParserOption) *Parse
 //
 // When the CommandHandler is invoked, we first gather all the parameterDefinitions from the
 // cmd (fresh on every invocation, because the parsers are allowed to modify them).
-func NewCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *Parser) CommandHandlerFunc {
+func NewCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) CommandHandlerFunc {
 	d := cmd.Description()
 
 	defaults := map[string]string{}

--- a/pkg/glazed/command.go
+++ b/pkg/glazed/command.go
@@ -97,10 +97,10 @@ func HandlePrepopulatedParameters(ps map[string]interface{}) CommandHandlerFunc 
 	}
 }
 
-// HandlePrepopulatedParsedLayers sets the given layers in the CommandContext's ParsedLayers,
+// HandlePrepopulatedParsedLayers sets the given layers in the CommandContext's Layers,
 // overriding the parameters of any layers that are already present.
-// This means that if a parameter is not set in layers_ but is set in the ParsedLayers,
-// the value in the ParsedLayers will be kept.
+// This means that if a parameter is not set in layers_ but is set in the Layers,
+// the value in the Layers will be kept.
 func HandlePrepopulatedParsedLayers(layers_ map[string]*layers.ParsedParameterLayer) CommandHandlerFunc {
 	return func(c *gin.Context, pc *CommandContext) error {
 		for k, v := range layers_ {
@@ -121,15 +121,15 @@ func NewCommandQueryParser(cmd cmds.GlazeCommand, options ...parser.ParserOption
 	d := cmd.Description()
 
 	ph := parser.NewParser()
-	ph.Parsers = []parser.ParserFunc{
-		parser.NewQueryParserFunc(false),
+	ph.Parsers = []parser.ParseStep{
+		parser.NewQueryParseStep(false),
 	}
 
 	// NOTE(manuel, 2023-04-16) API design: we would probably like to hide layers right here in the handler constructor
 	for _, l := range d.Layers {
 		slug := l.GetSlug()
-		ph.LayerParsersBySlug[slug] = []parser.ParserFunc{
-			parser.NewQueryParserFunc(false),
+		ph.LayerParsersBySlug[slug] = []parser.ParseStep{
+			parser.NewQueryParseStep(false),
 		}
 	}
 
@@ -144,15 +144,15 @@ func NewCommandFormParser(cmd cmds.GlazeCommand, options ...parser.ParserOption)
 	d := cmd.Description()
 
 	ph := parser.NewParser()
-	ph.Parsers = []parser.ParserFunc{
-		parser.NewFormParserFunc(false),
+	ph.Parsers = []parser.ParseStep{
+		parser.NewFormParseStep(false),
 	}
 
-	// NOTE(manuel, 2023-04-16) API design: we would probably like to hide layers right here in the handler constructor
+	// TODO(manuel, 2023-06-21) This is probably not necessary if the FormParseStep handles layers by itself
 	for _, l := range d.Layers {
 		slug := l.GetSlug()
-		ph.LayerParsersBySlug[slug] = []parser.ParserFunc{
-			parser.NewFormParserFunc(false),
+		ph.LayerParsersBySlug[slug] = []parser.ParseStep{
+			parser.NewFormParseStep(false),
 		}
 	}
 
@@ -184,7 +184,7 @@ func NewCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) 
 		}
 	}
 
-	// TODO(manuel, 2023-05-25) This is where we should handle default values provided from the config file, for example
+	// TODO(manuel, 2023-05-25) This is where we should handle default values provided from the config file
 	//
 	// See https://github.com/go-go-golems/sqleton/issues/161
 	//
@@ -206,52 +206,25 @@ func NewCommandHandlerFunc(cmd cmds.GlazeCommand, parserHandler *parser.Parser) 
 	var err error
 
 	return func(c *gin.Context, pc *CommandContext) error {
-		// Gather the ParameterDefinitions from the command description
-		// from scratch, because the parsers are allowed to modify the `pds` map.
-		//
-		// NOTE(2023-05-25, manuel) I wonder if we need `defaults` at all then.
-		// We could just as well store the defaults in the pds itself, since it seems
-		// that we only set them from the alias anyway (plus that seems broken...).
-		//
-		// See https://github.com/go-go-golems/sqleton/issues/151
-		pds := map[string]*parameters.ParameterDefinition{}
-		for _, p := range d.Flags {
-			pds[p.Name] = p
-		}
-		for _, p := range d.Arguments {
-			pds[p.Name] = p
+		parseState := parser.NewParseStateFromCommandDescription(d)
+		err = parserHandler.Parse(c, parseState)
+		if err != nil {
+			return err
 		}
 
-		for _, o := range parserHandler.Parsers {
-			pds, err = o(c, defaults, pc.ParsedParameters, pds)
-			if err != nil {
-				return err
+		pc.ParsedParameters = parseState.FlagsAndArguments.Parameters
+		pc.ParsedLayers = map[string]*layers.ParsedParameterLayer{}
+		commandLayers := pc.Cmd.Description().Layers
+		for _, v := range commandLayers {
+			parsedParameterLayer := &layers.ParsedParameterLayer{
+				Layer:      v,
+				Parameters: map[string]interface{}{},
 			}
-		}
-
-		for _, l := range d.Layers {
-			slug := l.GetSlug()
-			parsers, ok := parserHandler.LayerParsersBySlug[slug]
-			if !ok {
-				continue
+			parsedLayers, ok := parseState.Layers[v.GetSlug()]
+			if ok {
+				parsedParameterLayer.Parameters = parsedLayers.Parameters
 			}
-
-			_, ok = pc.ParsedLayers[slug]
-			if !ok {
-				pc.ParsedLayers[slug] = &layers.ParsedParameterLayer{
-					Layer:      l,
-					Parameters: map[string]interface{}{},
-				}
-			}
-
-			pds = l.GetParameterDefinitions()
-
-			for _, o := range parsers {
-				pds, err = o(c, defaults, pc.ParsedLayers[slug].Parameters, pds)
-				if err != nil {
-					return err
-				}
-			}
+			pc.ParsedLayers[v.GetSlug()] = parsedParameterLayer
 		}
 
 		return nil

--- a/pkg/glazed/handler.go
+++ b/pkg/glazed/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/formatters/yaml"
 	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/parka/pkg/glazed/parser"
 	"io"
 	"net/http"
 	"os"
@@ -28,7 +29,7 @@ type CreateProcessorFunc func(c *gin.Context, pc *CommandContext) (
 type HandleOptions struct {
 	// ParserOptions are passed to the given parser (the thing that gathers the glazed.Command
 	// flags and arguments.
-	ParserOptions []ParserOption
+	ParserOptions []parser.ParserOption
 
 	// Handlers are run right at the start to build up the CommandContext based on the
 	// gin.Context and the previous value of CommandContext.
@@ -69,7 +70,7 @@ func NewHandleOptions(options []HandleOption) *HandleOptions {
 	return opts
 }
 
-func WithParserOptions(parserOptions ...ParserOption) HandleOption {
+func WithParserOptions(parserOptions ...parser.ParserOption) HandleOption {
 	return func(o *HandleOptions) {
 		o.ParserOptions = parserOptions
 	}

--- a/pkg/glazed/handler.go
+++ b/pkg/glazed/handler.go
@@ -224,10 +224,6 @@ func runGlazeCommand(c *gin.Context, cmd cmds.GlazeCommand, opts *HandleOptions)
 		return err
 	}
 
-	// NOTE(manuel, 2023-04-16) API design wise, we might want to reuse gin.HandlerFunc here for lower processing
-	// For example, computing the response (?) I'm not sure this makes sense
-	// ANSWER(manuel, 2023-06-22) I don't remember what this actually means.
-
 	of := gp.OutputFormatter()
 
 	if opts.Writer == nil {

--- a/pkg/glazed/parser/default.go
+++ b/pkg/glazed/parser/default.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+type DefaultParseStep struct {
+	Parameters map[string]interface{}
+}
+
+func NewDefaultParseStep(parameters map[string]interface{}) *DefaultParseStep {
+	return &DefaultParseStep{
+		Parameters: parameters,
+	}
+}
+
+func (s *DefaultParseStep) Parse(_ *gin.Context, state *LayerParseState) error {
+	for k, v := range s.Parameters {
+		// first, check that we are supposed to parsed that parameter
+		if _, ok := state.ParameterDefinitions[k]; ok {
+			// then, check if the parameter is not set yet
+			if _, ok = state.Parameters[k]; !ok {
+				state.Parameters[k] = v
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/glazed/parser/form.go
+++ b/pkg/glazed/parser/form.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"strings"
+	"time"
+)
+
+type FormParseStep struct {
+	onlyDefined bool
+}
+
+func (f *FormParseStep) Parse(c *gin.Context, state *ParseState) error {
+	for _, p := range state.ParameterDefinitions {
+		value := c.DefaultPostForm(p.Name, state.Defaults[p.Name])
+		// TODO(manuel, 2023-02-28) is this enough to check if a file is missing?
+		if value == "" {
+			if p.Required {
+				return fmt.Errorf("required parameter '%s' is missing", p.Name)
+			}
+			if !f.onlyDefined {
+				if p.Type == parameters.ParameterTypeDate {
+					switch v := p.Default.(type) {
+					case string:
+						parsedDate, err := parameters.ParseDate(v)
+						if err != nil {
+							return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+						}
+
+						state.Parameters[p.Name] = parsedDate
+					case time.Time:
+						state.Parameters[p.Name] = v
+
+					}
+				} else {
+					state.Parameters[p.Name] = p.Default
+				}
+			}
+		} else if !parameters.IsFileLoadingParameter(p.Type, value) {
+			v := []string{value}
+			if p.Type == parameters.ParameterTypeStringList ||
+				p.Type == parameters.ParameterTypeIntegerList ||
+				p.Type == parameters.ParameterTypeFloatList {
+				v = strings.Split(value, ",")
+			}
+			pValue, err := p.ParseParameter(v)
+			if err != nil {
+				return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+			}
+			state.Parameters[p.Name] = pValue
+		} else if p.Type == parameters.ParameterTypeStringFromFile {
+			s, err := ParseStringFromFile(c, p.Name)
+			if err != nil {
+				return err
+			}
+			state.Parameters[p.Name] = s
+		} else if p.Type == parameters.ParameterTypeObjectFromFile {
+			obj, err := ParseObjectFromFile(c, p.Name)
+			if err != nil {
+				return err
+			}
+			state.Parameters[p.Name] = obj
+		} else if p.Type == parameters.ParameterTypeStringListFromFile {
+			// TODO(manuel, 2023-04-16) Add support for StringListFromFile and ObjectListFromFile
+			// See: https://github.com/go-go-golems/parka/issues/23
+			_ = state.Parameters
+		} else if p.Type == parameters.ParameterTypeObjectListFromFile {
+			// TODO(manuel, 2023-04-16) Add support for StringListFromFile and ObjectListFromFile
+			// See: https://github.com/go-go-golems/parka/issues/23
+			_ = state.Parameters
+		}
+	}
+
+	return nil
+}
+
+func NewFormParseStep(onlyDefined bool) *FormParseStep {
+	return &FormParseStep{
+		onlyDefined: onlyDefined,
+	}
+}
+
+// NewFormParserFunc returns a ParserFunc that takes an incoming multipart Form, and can thus also handle uploaded files.
+func NewFormParserFunc(onlyDefined bool) ParserFunc {
+	return func(c *gin.Context,
+		defaults map[string]string,
+		ps map[string]interface{},
+		pd map[string]*parameters.ParameterDefinition,
+	) (map[string]*parameters.ParameterDefinition, error) {
+		s := &ParseState{
+			Defaults:             defaults,
+			Parameters:           ps,
+			ParameterDefinitions: pd,
+		}
+		step := NewFormParseStep(onlyDefined)
+		err := step.Parse(c, s)
+		if err != nil {
+			return nil, err
+		}
+		return s.ParameterDefinitions, nil
+	}
+}

--- a/pkg/glazed/parser/form.go
+++ b/pkg/glazed/parser/form.go
@@ -12,7 +12,7 @@ type FormParseStep struct {
 	onlyDefined bool
 }
 
-func (f *FormParseStep) Parse(c *gin.Context, state *ParseState) error {
+func (f *FormParseStep) ParseLayerState(c *gin.Context, state *LayerParseState) error {
 	for _, p := range state.ParameterDefinitions {
 		value := c.DefaultPostForm(p.Name, state.Defaults[p.Name])
 		// TODO(manuel, 2023-02-28) is this enough to check if a file is missing?
@@ -76,29 +76,17 @@ func (f *FormParseStep) Parse(c *gin.Context, state *ParseState) error {
 	return nil
 }
 
+func (f *FormParseStep) Parse(c *gin.Context, state *LayerParseState) error {
+	err := f.ParseLayerState(c, state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func NewFormParseStep(onlyDefined bool) *FormParseStep {
 	return &FormParseStep{
 		onlyDefined: onlyDefined,
-	}
-}
-
-// NewFormParserFunc returns a ParserFunc that takes an incoming multipart Form, and can thus also handle uploaded files.
-func NewFormParserFunc(onlyDefined bool) ParserFunc {
-	return func(c *gin.Context,
-		defaults map[string]string,
-		ps map[string]interface{},
-		pd map[string]*parameters.ParameterDefinition,
-	) (map[string]*parameters.ParameterDefinition, error) {
-		s := &ParseState{
-			Defaults:             defaults,
-			Parameters:           ps,
-			ParameterDefinitions: pd,
-		}
-		step := NewFormParseStep(onlyDefined)
-		err := step.Parse(c, s)
-		if err != nil {
-			return nil, err
-		}
-		return s.ParameterDefinitions, nil
 	}
 }

--- a/pkg/glazed/parser/form.go
+++ b/pkg/glazed/parser/form.go
@@ -21,21 +21,23 @@ func (f *FormParseStep) ParseLayerState(c *gin.Context, state *LayerParseState) 
 				return fmt.Errorf("required parameter '%s' is missing", p.Name)
 			}
 			if !f.onlyDefined {
-				if p.Type == parameters.ParameterTypeDate {
-					switch v := p.Default.(type) {
-					case string:
-						parsedDate, err := parameters.ParseDate(v)
-						if err != nil {
-							return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+				if _, ok := state.Parameters[p.Name]; !ok {
+					if p.Type == parameters.ParameterTypeDate {
+						switch v := p.Default.(type) {
+						case string:
+							parsedDate, err := parameters.ParseDate(v)
+							if err != nil {
+								return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+							}
+
+							state.Parameters[p.Name] = parsedDate
+						case time.Time:
+							state.Parameters[p.Name] = v
+
 						}
-
-						state.Parameters[p.Name] = parsedDate
-					case time.Time:
-						state.Parameters[p.Name] = v
-
+					} else {
+						state.Parameters[p.Name] = p.Default
 					}
-				} else {
-					state.Parameters[p.Name] = p.Default
 				}
 			}
 		} else if !parameters.IsFileLoadingParameter(p.Type, value) {

--- a/pkg/glazed/parser/helpers.go
+++ b/pkg/glazed/parser/helpers.go
@@ -1,0 +1,77 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+	"io"
+	"mime/multipart"
+	"strings"
+)
+
+// ParseStringFromFile takes a multipart.File named `name` from the request and reads it into a string.
+func ParseStringFromFile(c *gin.Context, name string) (string, error) {
+	file, _, err := c.Request.FormFile(name)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving file '%s': %v", name, err)
+	}
+	defer func(file multipart.File) {
+		err := file.Close()
+		if err != nil {
+			log.Error().Err(err).Msgf("error closing file '%s'", name)
+		}
+	}(file)
+
+	fileBytes, err := io.ReadAll(file)
+	if err != nil {
+		return "", fmt.Errorf("error reading contents of file '%s': %v", name, err)
+	}
+
+	return string(fileBytes), nil
+}
+
+// ParseObjectFromFile takes a multipart.File named `name` from the request and reads it into a map[string]interface{}.
+// If the file is a JSON file (ends with .json), it will be parsed as JSON,
+// if it ends with .yaml or .yml, it will be parsed as YAML.
+func ParseObjectFromFile(c *gin.Context, name string) (map[string]interface{}, error) {
+	file, fileHeader, err := c.Request.FormFile(name)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving file '%s': %v", name, err)
+	}
+	defer func(file multipart.File) {
+		err := file.Close()
+		if err != nil {
+			log.Error().Err(err).Msgf("error closing file '%s'", name)
+		}
+	}(file)
+
+	// NOTE(manuel, 2023-04-16) We should actually look at the MIME type of the file instead of the file name
+	// See https://github.com/go-go-golems/parka/issues/24
+
+	// NOTE(manuel, 2023-04-16) We should support CSV and excel files here too. Excel might be more complicated because of multiple sheets and locations.
+	// See https://github.com/go-go-golems/parka/issues/25
+
+	fileBytes, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("error reading contents of file '%s': %v", name, err)
+	}
+
+	var obj map[string]interface{}
+	if strings.HasSuffix(fileHeader.Filename, ".json") {
+		err = json.Unmarshal(fileBytes, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing contents of file '%s' as JSON: %v", fileHeader.Filename, err)
+		}
+	} else if strings.HasSuffix(fileHeader.Filename, ".yaml") || strings.HasSuffix(fileHeader.Filename, ".yml") {
+		err = yaml.Unmarshal(fileBytes, &obj)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing contents of file '%s' as YAML: %v", fileHeader.Filename, err)
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported file format for file '%s'", fileHeader.Filename)
+	}
+
+	return obj, nil
+}

--- a/pkg/glazed/parser/parser.go
+++ b/pkg/glazed/parser/parser.go
@@ -1,22 +1,16 @@
 package parser
 
 import (
-	"encoding/json"
-	"fmt"
 	"github.com/gin-gonic/gin"
-	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v3"
-	"io"
-	"mime/multipart"
-	"strings"
 )
 
 // TODO(manuel, 2023-06-21) This part of the API is a complete mess, I'm not even sure what it is supposed to do overall
 // Well worth refactoring
 
-type ParseState struct {
+type LayerParseState struct {
+	Slug string
 	// Defaults contains the default values for the parameters, as strings to be parsed
 	// NOTE(manuel, 2023-06-21) Why are these strings?
 	// See also https://github.com/go-go-golems/glazed/issues/239
@@ -27,149 +21,49 @@ type ParseState struct {
 	ParameterDefinitions map[string]*parameters.ParameterDefinition
 }
 
+type ParseState struct {
+	FlagsAndArguments *LayerParseState
+	Layers            map[string]*LayerParseState
+}
+
+func NewParseStateFromCommandDescription(d *cmds.CommandDescription) *ParseState {
+	ret := &ParseState{
+		FlagsAndArguments: &LayerParseState{
+			Defaults:             map[string]string{},
+			Parameters:           map[string]interface{}{},
+			ParameterDefinitions: map[string]*parameters.ParameterDefinition{},
+		},
+		Layers: map[string]*LayerParseState{},
+	}
+
+	for _, p := range d.Flags {
+		ret.FlagsAndArguments.ParameterDefinitions[p.Name] = p
+	}
+	for _, p := range d.Arguments {
+		ret.FlagsAndArguments.ParameterDefinitions[p.Name] = p
+	}
+
+	for _, l := range d.Layers {
+		ret.Layers[l.GetSlug()] = &LayerParseState{
+			Slug:                 l.GetSlug(),
+			Defaults:             map[string]string{},
+			Parameters:           map[string]interface{}{},
+			ParameterDefinitions: map[string]*parameters.ParameterDefinition{},
+		}
+
+		for _, p := range l.GetParameterDefinitions() {
+			ret.Layers[l.GetSlug()].ParameterDefinitions[p.Name] = p
+		}
+	}
+
+	return ret
+}
+
 // ParseStep is used to parse parameters out of a gin.Context (meaning most certainly out of an incoming *http.Request).
 // These parsed parameters are stored in the ParseState structure.
 // A ParseStep can only parse parameters that are given in the ParameterDefinitions field of the ParseState.
 type ParseStep interface {
-	Parse(c *gin.Context, result *ParseState) error
-}
-
-// ParserFunc is used to parse parameters out of a gin.Context (meaning
-// most certainly out of an incoming *http.Request). These parameters
-// are stored in the hashmap `ps`, according to the parameter definitions
-// in `pds`.
-//
-// If a parameter definition shouldn't be handled by a follow up step, return a new hashmap
-// with the key deleted.
-type ParserFunc func(
-	c *gin.Context,
-	// This is not pretty, but it's needed to handle aliases until https://github.com/go-go-golems/glazed/issues/287
-	// is built.
-	defaults map[string]string,
-	ps map[string]interface{},
-	pds map[string]*parameters.ParameterDefinition,
-) (map[string]*parameters.ParameterDefinition, error)
-
-// ParseStringFromFile takes a multipart.File named `name` from the request and reads it into a string.
-func ParseStringFromFile(c *gin.Context, name string) (string, error) {
-	file, _, err := c.Request.FormFile(name)
-	if err != nil {
-		return "", fmt.Errorf("error retrieving file '%s': %v", name, err)
-	}
-	defer func(file multipart.File) {
-		err := file.Close()
-		if err != nil {
-			log.Error().Err(err).Msgf("error closing file '%s'", name)
-		}
-	}(file)
-
-	fileBytes, err := io.ReadAll(file)
-	if err != nil {
-		return "", fmt.Errorf("error reading contents of file '%s': %v", name, err)
-	}
-
-	return string(fileBytes), nil
-}
-
-// ParseObjectFromFile takes a multipart.File named `name` from the request and reads it into a map[string]interface{}.
-// If the file is a JSON file (ends with .json), it will be parsed as JSON,
-// if it ends with .yaml or .yml, it will be parsed as YAML.
-func ParseObjectFromFile(c *gin.Context, name string) (map[string]interface{}, error) {
-	file, fileHeader, err := c.Request.FormFile(name)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving file '%s': %v", name, err)
-	}
-	defer func(file multipart.File) {
-		err := file.Close()
-		if err != nil {
-			log.Error().Err(err).Msgf("error closing file '%s'", name)
-		}
-	}(file)
-
-	// NOTE(manuel, 2023-04-16) We should actually look at the MIME type of the file instead of the file name
-	// See https://github.com/go-go-golems/parka/issues/24
-
-	// NOTE(manuel, 2023-04-16) We should support CSV and excel files here too. Excel might be more complicated because of multiple sheets and locations.
-	// See https://github.com/go-go-golems/parka/issues/25
-
-	fileBytes, err := io.ReadAll(file)
-	if err != nil {
-		return nil, fmt.Errorf("error reading contents of file '%s': %v", name, err)
-	}
-
-	var obj map[string]interface{}
-	if strings.HasSuffix(fileHeader.Filename, ".json") {
-		err = json.Unmarshal(fileBytes, &obj)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing contents of file '%s' as JSON: %v", fileHeader.Filename, err)
-		}
-	} else if strings.HasSuffix(fileHeader.Filename, ".yaml") || strings.HasSuffix(fileHeader.Filename, ".yml") {
-		err = yaml.Unmarshal(fileBytes, &obj)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing contents of file '%s' as YAML: %v", fileHeader.Filename, err)
-		}
-	} else {
-		return nil, fmt.Errorf("unsupported file format for file '%s'", fileHeader.Filename)
-	}
-
-	return obj, nil
-}
-
-// NewStaticParserFunc returns a parser that adds the given static parameters to the parameter map.
-func NewStaticParserFunc(ps map[string]interface{}) ParserFunc {
-	return func(
-		c *gin.Context,
-		_ map[string]string,
-		ps_ map[string]interface{},
-		pds map[string]*parameters.ParameterDefinition,
-	) (map[string]*parameters.ParameterDefinition, error) {
-		// add the static parameters
-		for k, v := range ps {
-			ps_[k] = v
-		}
-
-		// no more parsing after this
-		return map[string]*parameters.ParameterDefinition{}, nil
-	}
-}
-
-// NewDefaultsFromLayerParserFunc returns a parser that adds the default values from the given
-// layers.ParameterLayer to the parameter map (if they haven't been set in the `defaults` map first,
-// which needs to be replaced anyway.
-//
-// NOTE(manuel, 2023-04-16) How this actually relate to the ParkaContext...
-// NOTE(manuel, 2023-05-25) We shouldn't be dealing with the `defaults` map here
-func NewDefaultsFromLayerParserFunc(l layers.ParameterLayer) ParserFunc {
-	return func(
-		c *gin.Context,
-		defaults map[string]string,
-		ps_ map[string]interface{},
-		pds map[string]*parameters.ParameterDefinition,
-	) (map[string]*parameters.ParameterDefinition, error) {
-		// add the static parameters
-		for _, pd := range l.GetParameterDefinitions() {
-			// here we need to parse the default
-			default_, ok := defaults[pd.Name]
-			if ok {
-				vs := []string{default_}
-				if parameters.IsListParameter(pd.Type) {
-					vs = strings.Split(default_, ",")
-				}
-				v, err := pd.ParseParameter(vs)
-				if err != nil {
-					return nil, fmt.Errorf("error parsing default value for parameter '%s': %v", pd.Name, err)
-				}
-				ps_[pd.Name] = v
-			} else {
-				if pd.Default != nil {
-					ps_[pd.Name] = pd.Default
-				}
-			}
-		}
-
-		// no more parsing after this
-		return map[string]*parameters.ParameterDefinition{}, nil
-	}
+	Parse(c *gin.Context, result *LayerParseState) error
 }
 
 // Parser is contains a list of ParserFunc that are used to parse an incoming
@@ -183,16 +77,16 @@ func NewDefaultsFromLayerParserFunc(l layers.ParameterLayer) ParserFunc {
 // We might actually already do this by leveraging it to overwrite layer parameters (say, sqleton
 // connection parameters).
 type Parser struct {
-	Parsers            []ParserFunc
-	LayerParsersBySlug map[string][]ParserFunc
+	Parsers            []ParseStep
+	LayerParsersBySlug map[string][]ParseStep
 }
 
 type ParserOption func(*Parser)
 
 func NewParser(options ...ParserOption) *Parser {
 	ph := &Parser{
-		Parsers:            []ParserFunc{},
-		LayerParsersBySlug: map[string][]ParserFunc{},
+		Parsers:            []ParseStep{},
+		LayerParsersBySlug: map[string][]ParseStep{},
 	}
 
 	for _, option := range options {
@@ -202,11 +96,31 @@ func NewParser(options ...ParserOption) *Parser {
 	return ph
 }
 
-// NOTE(manuel, 2023-04-16) This might be better called WithPrependParserFunc ? What is a better name for ParserFunc.
+func (p *Parser) Parse(c *gin.Context, state *ParseState) error {
+	for _, parser := range p.Parsers {
+		if err := parser.Parse(c, state.FlagsAndArguments); err != nil {
+			return err
+		}
+	}
+
+	for _, layer := range state.Layers {
+		for _, parser := range p.LayerParsersBySlug[layer.Slug] {
+			if err := parser.Parse(c, layer); err != nil {
+				return err
+			}
+		}
+	}
+
+	// NOTE(manuel, 2023-06-21) We might have to copy each layer's parsed parameters back to the main Parameters
+	// either here or further down the road when calling the glazed command since many commands might still
+	// rely on getting layer specific flags in ps[] itself.
+
+	return nil
+}
 
 // WithPrependParser adds the given ParserFunc to the beginning of the list of parsers.
 // Be mindful that this can later on be overwritten by a WithReplaceParser.
-func WithPrependParser(ps ...ParserFunc) ParserOption {
+func WithPrependParser(ps ...ParseStep) ParserOption {
 	return func(ph *Parser) {
 		ph.Parsers = append(ps, ph.Parsers...)
 	}
@@ -214,7 +128,7 @@ func WithPrependParser(ps ...ParserFunc) ParserOption {
 
 // WithAppendParser adds the given ParserFunc to the end of the list of parsers.
 // Be mindful that this can later on be overwritten by a WithReplaceParser.
-func WithAppendParser(ps ...ParserFunc) ParserOption {
+func WithAppendParser(ps ...ParseStep) ParserOption {
 	return func(ph *Parser) {
 		ph.Parsers = append(ph.Parsers, ps...)
 	}
@@ -222,7 +136,7 @@ func WithAppendParser(ps ...ParserFunc) ParserOption {
 
 // WithReplaceParser replaces the list of parsers with the given ParserFunc.
 // This will remove all previously added prepend, replace, append parsers.
-func WithReplaceParser(ps ...ParserFunc) ParserOption {
+func WithReplaceParser(ps ...ParseStep) ParserOption {
 	return func(ph *Parser) {
 		ph.Parsers = ps
 	}
@@ -230,10 +144,10 @@ func WithReplaceParser(ps ...ParserFunc) ParserOption {
 
 // WithPrependLayerParser adds the given ParserFunc to the beginning of the list of layer parsers.
 // Be mindful that this can later on be overwritten by a WithReplaceLayerParser.
-func WithPrependLayerParser(slug string, ps ...ParserFunc) ParserOption {
+func WithPrependLayerParser(slug string, ps ...ParseStep) ParserOption {
 	return func(ph *Parser) {
 		if _, ok := ph.LayerParsersBySlug[slug]; !ok {
-			ph.LayerParsersBySlug[slug] = []ParserFunc{}
+			ph.LayerParsersBySlug[slug] = []ParseStep{}
 		}
 		ph.LayerParsersBySlug[slug] = append(ps, ph.LayerParsersBySlug[slug]...)
 	}
@@ -241,39 +155,27 @@ func WithPrependLayerParser(slug string, ps ...ParserFunc) ParserOption {
 
 // WithAppendLayerParser adds the given ParserFunc to the end of the list of layer parsers.
 // Be mindful that this can later on be overwritten by a WithReplaceLayerParser.
-func WithAppendLayerParser(slug string, ps ...ParserFunc) ParserOption {
+func WithAppendLayerParser(slug string, ps ...ParseStep) ParserOption {
 	return func(ph *Parser) {
 		if _, ok := ph.LayerParsersBySlug[slug]; !ok {
-			ph.LayerParsersBySlug[slug] = []ParserFunc{}
+			ph.LayerParsersBySlug[slug] = []ParseStep{}
 		}
 		ph.LayerParsersBySlug[slug] = append(ph.LayerParsersBySlug[slug], ps...)
 	}
 }
 
 // WithReplaceLayerParser replaces the list of layer parsers with the given ParserFunc.
-func WithReplaceLayerParser(slug string, ps ...ParserFunc) ParserOption {
+func WithReplaceLayerParser(slug string, ps ...ParseStep) ParserOption {
 	return func(ph *Parser) {
 		ph.LayerParsersBySlug[slug] = ps
 	}
-}
-
-// WithReplaceCustomizedParameterLayerParser adds a DefaultFromLayerParserFunc tweaked by the given
-// `overrides` map. This entirely replaces the current layer parser, but can later on be amended
-// with other parsers, for example with WithAppendOverrideLayer.
-func WithReplaceCustomizedParameterLayerParser(l layers.ParameterLayer, overrides map[string]interface{}) ParserOption {
-	slug := l.GetSlug()
-	return WithReplaceLayerParser(
-		slug,
-		NewDefaultsFromLayerParserFunc(l),
-		NewStaticParserFunc(overrides),
-	)
 }
 
 // WithGlazeOutputParserOption is a convenience function to override the output and table format glazed settings.
 func WithGlazeOutputParserOption(output string, tableFormat string) ParserOption {
 	return WithAppendLayerParser(
 		"glazed",
-		NewStaticParserFunc(map[string]interface{}{
+		NewStaticParseStep(map[string]interface{}{
 			"output":       output,
 			"table-format": tableFormat,
 		}),
@@ -286,7 +188,7 @@ func WithGlazeOutputParserOption(output string, tableFormat string) ParserOption
 func WithReplaceStaticLayer(slug string, overrides map[string]interface{}) ParserOption {
 	return WithReplaceLayerParser(
 		slug,
-		NewStaticParserFunc(overrides),
+		NewStaticParseStep(overrides),
 	)
 }
 
@@ -295,6 +197,6 @@ func WithReplaceStaticLayer(slug string, overrides map[string]interface{}) Parse
 func WithAppendOverrideLayer(slug string, overrides map[string]interface{}) ParserOption {
 	return WithAppendLayerParser(
 		slug,
-		NewStaticParserFunc(overrides),
+		NewStaticParseStep(overrides),
 	)
 }

--- a/pkg/glazed/parser/query.go
+++ b/pkg/glazed/parser/query.go
@@ -25,7 +25,9 @@ func (q *QueryParseStep) ParseLayerState(c *gin.Context, state *LayerParseState)
 					return errors.Errorf("required parameter '%s' is missing", p.Name)
 				}
 				if !q.onlyDefined {
-					state.Parameters[p.Name] = p.Default
+					if _, ok := state.Parameters[p.Name]; !ok {
+						state.Parameters[p.Name] = p.Default
+					}
 				}
 			} else {
 				f := strings.NewReader(value)
@@ -55,7 +57,10 @@ func (q *QueryParseStep) ParseLayerState(c *gin.Context, state *LayerParseState)
 
 						}
 					} else {
-						state.Parameters[p.Name] = p.Default
+						// only set default value if it is not already set
+						if _, ok := state.Parameters[p.Name]; !ok {
+							state.Parameters[p.Name] = p.Default
+						}
 					}
 				}
 			} else {

--- a/pkg/glazed/parser/query.go
+++ b/pkg/glazed/parser/query.go
@@ -14,7 +14,7 @@ type QueryParseStep struct {
 	onlyDefined bool
 }
 
-func (q *QueryParseStep) Parse(c *gin.Context, state *ParseState) error {
+func (q *QueryParseStep) ParseLayerState(c *gin.Context, state *LayerParseState) error {
 	for _, p := range state.ParameterDefinitions {
 		value := c.DefaultQuery(p.Name, state.Defaults[p.Name])
 		if parameters.IsFileLoadingParameter(p.Type, value) {
@@ -77,31 +77,17 @@ func (q *QueryParseStep) Parse(c *gin.Context, state *ParseState) error {
 	return nil
 }
 
+func (q *QueryParseStep) Parse(c *gin.Context, state *LayerParseState) error {
+	err := q.ParseLayerState(c, state)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func NewQueryParseStep(onlyDefined bool) ParseStep {
 	return &QueryParseStep{
 		onlyDefined: onlyDefined,
-	}
-}
-
-// NewQueryParserFunc returns a ParserFunc that can handle an incoming GET query string.
-// If the parameter is supposed to be read from a file, we will just pass in the query parameter's value.
-func NewQueryParserFunc(onlyDefined bool) ParserFunc {
-	return func(
-		c *gin.Context,
-		defaults map[string]string,
-		ps map[string]interface{},
-		pd map[string]*parameters.ParameterDefinition,
-	) (map[string]*parameters.ParameterDefinition, error) {
-		s := &ParseState{
-			Defaults:             defaults,
-			Parameters:           ps,
-			ParameterDefinitions: pd,
-		}
-		step := NewQueryParseStep(onlyDefined)
-		err := step.Parse(c, s)
-		if err != nil {
-			return nil, err
-		}
-		return s.ParameterDefinitions, nil
 	}
 }

--- a/pkg/glazed/parser/query.go
+++ b/pkg/glazed/parser/query.go
@@ -1,0 +1,107 @@
+package parser
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/pkg/errors"
+	"strings"
+	"time"
+)
+
+// QueryParseStep parses parameters from the query string of a request.
+type QueryParseStep struct {
+	onlyDefined bool
+}
+
+func (q *QueryParseStep) Parse(c *gin.Context, state *ParseState) error {
+	for _, p := range state.ParameterDefinitions {
+		value := c.DefaultQuery(p.Name, state.Defaults[p.Name])
+		if parameters.IsFileLoadingParameter(p.Type, value) {
+			// if the parameter is supposed to be read from a file, we will just pass in the query parameters
+			// as a placeholder here
+			if value == "" {
+				if p.Required {
+					return errors.Errorf("required parameter '%s' is missing", p.Name)
+				}
+				if !q.onlyDefined {
+					state.Parameters[p.Name] = p.Default
+				}
+			} else {
+				f := strings.NewReader(value)
+				pValue, err := p.ParseFromReader(f, "")
+				if err != nil {
+					return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+				}
+				state.Parameters[p.Name] = pValue
+			}
+		} else {
+			if value == "" {
+				if p.Required {
+					return fmt.Errorf("required parameter '%s' is missing", p.Name)
+				}
+				if !q.onlyDefined {
+					if p.Type == parameters.ParameterTypeDate {
+						switch v := p.Default.(type) {
+						case string:
+							parsedDate, err := parameters.ParseDate(v)
+							if err != nil {
+								return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+							}
+
+							state.Parameters[p.Name] = parsedDate
+						case time.Time:
+							state.Parameters[p.Name] = v
+
+						}
+					} else {
+						state.Parameters[p.Name] = p.Default
+					}
+				}
+			} else {
+				var values []string
+				if parameters.IsListParameter(p.Type) {
+					values = strings.Split(value, ",")
+				} else {
+					values = []string{value}
+				}
+				pValue, err := p.ParseParameter(values)
+				if err != nil {
+					return fmt.Errorf("invalid value for parameter '%s': (%v) %s", p.Name, value, err.Error())
+				}
+				state.Parameters[p.Name] = pValue
+			}
+		}
+	}
+
+	return nil
+}
+
+func NewQueryParseStep(onlyDefined bool) ParseStep {
+	return &QueryParseStep{
+		onlyDefined: onlyDefined,
+	}
+}
+
+// NewQueryParserFunc returns a ParserFunc that can handle an incoming GET query string.
+// If the parameter is supposed to be read from a file, we will just pass in the query parameter's value.
+func NewQueryParserFunc(onlyDefined bool) ParserFunc {
+	return func(
+		c *gin.Context,
+		defaults map[string]string,
+		ps map[string]interface{},
+		pd map[string]*parameters.ParameterDefinition,
+	) (map[string]*parameters.ParameterDefinition, error) {
+		s := &ParseState{
+			Defaults:             defaults,
+			Parameters:           ps,
+			ParameterDefinitions: pd,
+		}
+		step := NewQueryParseStep(onlyDefined)
+		err := step.Parse(c, s)
+		if err != nil {
+			return nil, err
+		}
+		return s.ParameterDefinitions, nil
+	}
+}

--- a/pkg/glazed/parser/query_test.go
+++ b/pkg/glazed/parser/query_test.go
@@ -33,7 +33,7 @@ func TestEmptyQueryOnlyDefined(t *testing.T) {
 	ps := NewQueryParseStep(true)
 
 	parameterDefinitions, _ := parameters.LoadParameterDefinitionsFromYAML(queryYAML)
-	state := &ParseState{
+	state := &LayerParseState{
 		// can we parse that from yaml
 		ParameterDefinitions: parameterDefinitions,
 		Defaults:             map[string]string{},
@@ -52,7 +52,7 @@ func TestEmptyQuery(t *testing.T) {
 	ps := NewQueryParseStep(false)
 
 	parameterDefinitions, _ := parameters.LoadParameterDefinitionsFromYAML(queryYAML)
-	state := &ParseState{
+	state := &LayerParseState{
 		// can we parse that from yaml
 		ParameterDefinitions: parameterDefinitions,
 		Defaults:             map[string]string{},

--- a/pkg/glazed/parser/query_test.go
+++ b/pkg/glazed/parser/query_test.go
@@ -1,0 +1,70 @@
+package parser
+
+import (
+	_ "embed"
+	"github.com/gin-gonic/gin"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+)
+
+//go:embed tests/query.yaml
+var queryYAML []byte
+
+func createHTTPRequestWithQueryValues(value map[string]string) *http.Request {
+	req, _ := http.NewRequest("GET", "/test", nil)
+	q := req.URL.Query()
+	for k, v := range value {
+		q.Add(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+	return req
+}
+
+func createGinContextWithQueryValues(value map[string]string) *gin.Context {
+	req := createHTTPRequestWithQueryValues(value)
+	return &gin.Context{
+		Request: req,
+	}
+}
+
+func TestEmptyQueryOnlyDefined(t *testing.T) {
+	ps := NewQueryParseStep(true)
+
+	parameterDefinitions, _ := parameters.LoadParameterDefinitionsFromYAML(queryYAML)
+	state := &ParseState{
+		// can we parse that from yaml
+		ParameterDefinitions: parameterDefinitions,
+		Defaults:             map[string]string{},
+		Parameters:           map[string]interface{}{},
+	}
+
+	c := createGinContextWithQueryValues(map[string]string{})
+
+	err := ps.Parse(c, state)
+	require.Nil(t, err)
+
+	require.Equal(t, 0, len(state.Parameters))
+}
+
+func TestEmptyQuery(t *testing.T) {
+	ps := NewQueryParseStep(false)
+
+	parameterDefinitions, _ := parameters.LoadParameterDefinitionsFromYAML(queryYAML)
+	state := &ParseState{
+		// can we parse that from yaml
+		ParameterDefinitions: parameterDefinitions,
+		Defaults:             map[string]string{},
+		Parameters:           map[string]interface{}{},
+	}
+
+	c := createGinContextWithQueryValues(map[string]string{})
+
+	err := ps.Parse(c, state)
+	require.Nil(t, err)
+
+	require.Equal(t, 2, len(state.Parameters))
+	require.Equal(t, "default", state.Parameters["testDefault"])
+	require.Nil(t, state.Parameters["test"])
+}

--- a/pkg/glazed/parser/static.go
+++ b/pkg/glazed/parser/static.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 )
 
 type StaticParseStep struct {
@@ -19,12 +18,6 @@ func (s *StaticParseStep) Parse(_ *gin.Context, state *LayerParseState) error {
 	for k, v := range s.Parameters {
 		state.Parameters[k] = v
 	}
-
-	// NOTE(manuel, 2023-06-21) This could maybe better be done with a "StopParsingStep" that can be put
-	// at the end of a chain.
-
-	// no more parsing after this
-	state.ParameterDefinitions = map[string]*parameters.ParameterDefinition{}
 
 	return nil
 }

--- a/pkg/glazed/parser/static.go
+++ b/pkg/glazed/parser/static.go
@@ -1,0 +1,30 @@
+package parser
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+)
+
+type StaticParseStep struct {
+	Parameters map[string]interface{}
+}
+
+func NewStaticParseStep(parameters map[string]interface{}) *StaticParseStep {
+	return &StaticParseStep{
+		Parameters: parameters,
+	}
+}
+
+func (s *StaticParseStep) Parse(_ *gin.Context, state *LayerParseState) error {
+	for k, v := range s.Parameters {
+		state.Parameters[k] = v
+	}
+
+	// NOTE(manuel, 2023-06-21) This could maybe better be done with a "StopParsingStep" that can be put
+	// at the end of a chain.
+
+	// no more parsing after this
+	state.ParameterDefinitions = map[string]*parameters.ParameterDefinition{}
+
+	return nil
+}

--- a/pkg/glazed/parser/stop.go
+++ b/pkg/glazed/parser/stop.go
@@ -1,0 +1,21 @@
+package parser
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+)
+
+// StopParseStep is a step that stops the parsing process.
+// No more parameter definitions will be parsed after this step.
+type StopParseStep struct{}
+
+func NewStopParseStep() *StopParseStep {
+	return &StopParseStep{}
+}
+
+func (s *StopParseStep) Parse(_ *gin.Context, state *LayerParseState) error {
+	// no more parsing after this
+	state.ParameterDefinitions = map[string]*parameters.ParameterDefinition{}
+
+	return nil
+}

--- a/pkg/glazed/parser/tests/query.yaml
+++ b/pkg/glazed/parser/tests/query.yaml
@@ -1,0 +1,7 @@
+- name: test
+  type: string
+  short: Test flag
+- name: testDefault
+  type: string
+  short: Test flag with default
+  default: default

--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -421,13 +421,9 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 			return
 		}
 
-		jsonProcessorFunc := glazed.CreateJSONProcessor
-
-		parserOptions := cd.computeParserOptions()
-
 		handle := server.HandleSimpleQueryCommand(sqlCommand,
-			glazed.WithCreateProcessor(jsonProcessorFunc),
-			glazed.WithParserOptions(parserOptions...),
+			glazed.WithCreateProcessor(glazed.CreateJSONProcessor),
+			glazed.WithParserOptions(cd.computeParserOptions()...),
 		)
 
 		handle(c)
@@ -449,32 +445,32 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 			dateTime := time.Now().Format("2006-01-02--15-04-05")
 			links := []layout.Link{
 				{
-					Href:  fmt.Sprintf("/download/%s/%s-%s.csv", commandPath, dateTime, name),
+					Href:  fmt.Sprintf("%s/download/%s/%s-%s.csv", path, commandPath, dateTime, name),
 					Text:  "Download CSV",
 					Class: "download",
 				},
 				{
-					Href:  fmt.Sprintf("/download/%s/%s-%s.json", commandPath, dateTime, name),
+					Href:  fmt.Sprintf("%s/download/%s/%s-%s.json", path, commandPath, dateTime, name),
 					Text:  "Download JSON",
 					Class: "download",
 				},
 				{
-					Href:  fmt.Sprintf("/download/%s/%s-%s.xlsx", commandPath, dateTime, name),
+					Href:  fmt.Sprintf("%s/download/%s/%s-%s.xlsx", path, commandPath, dateTime, name),
 					Text:  "Download Excel",
 					Class: "download",
 				},
 				{
-					Href:  fmt.Sprintf("/download/%s/%s-%s.md", commandPath, dateTime, name),
+					Href:  fmt.Sprintf("%s/download/%s/%s-%s.md", path, commandPath, dateTime, name),
 					Text:  "Download Markdown",
 					Class: "download",
 				},
 				{
-					Href:  fmt.Sprintf("/download/%s/%s-%s.html", commandPath, dateTime, name),
+					Href:  fmt.Sprintf("%s/download/%s/%s-%s.html", path, commandPath, dateTime, name),
 					Text:  "Download HTML",
 					Class: "download",
 				},
 				{
-					Href:  fmt.Sprintf("/download/%s/%s-%s.txt", commandPath, dateTime, name),
+					Href:  fmt.Sprintf("%s/download/%s/%s-%s.txt", path, commandPath, dateTime, name),
 					Text:  "Download Text",
 					Class: "download",
 				},
@@ -490,22 +486,13 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 				datatables.WithLinks(links...),
 				datatables.WithJSRendering(),
 				datatables.WithAdditionalData(cd.AdditionalData),
+				datatables.WithBasePath(path),
 			)
-
-			// TODO(manuel, 2023-06-21) We also need to handle:
-			// - IndexTemplateName
-			// - TemplateDirectory (by replacing TemplateLookup)
-			//
-			// don't exist in config file yet:
-			// - UseDefaultParkaTemplate
-			parserOptions := cd.computeParserOptions()
 
 			handle := server.HandleSimpleQueryCommand(
 				sqlCommand,
-				glazed.WithCreateProcessor(
-					dataTablesProcessorFunc,
-				),
-				glazed.WithParserOptions(parserOptions...),
+				glazed.WithCreateProcessor(dataTablesProcessorFunc),
+				glazed.WithParserOptions(cd.computeParserOptions()...),
 			)
 
 			handle(c)

--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -167,16 +167,33 @@ func WithOverrideArgument(name string, value string) CommandDirHandlerOption {
 	}
 }
 
-func WithMergeOverrideLayer(name string, layer *layers.ParsedParameterLayer) CommandDirHandlerOption {
+func WithMergeOverrideLayer(name string, layer map[string]interface{}) CommandDirHandlerOption {
 	return func(handler *CommandDirHandler) {
 		if handler.Overrides == nil {
 			handler.Overrides = NewHandlerParameters()
 		}
-		for k, v := range layer.Parameters {
+		for k, v := range layer {
 			if _, ok := handler.Overrides.Layers[name]; !ok {
 				handler.Overrides.Layers[name] = map[string]interface{}{}
 			}
 			handler.Overrides.Layers[name][k] = v
+		}
+	}
+}
+
+// WithLayerDefaults populates the defaults for the given layer. If a value is already set, the value is skipped.
+func WithLayerDefaults(name string, layer map[string]interface{}) CommandDirHandlerOption {
+	return func(handler *CommandDirHandler) {
+		if handler.Overrides == nil {
+			handler.Overrides = NewHandlerParameters()
+		}
+		for k, v := range layer {
+			if _, ok := handler.Overrides.Layers[name]; !ok {
+				handler.Overrides.Layers[name] = map[string]interface{}{}
+			}
+			if _, ok := handler.Overrides.Layers[name][k]; !ok {
+				handler.Overrides.Layers[name][k] = v
+			}
 		}
 	}
 }

--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -396,6 +396,10 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 			//
 			// ANSWER(manuel, 2023-06-22) Defaults should actually work by prepending them to the parsers,
 			// so that they fill the initial value. Not fully sure yet, let's give it a try actually.
+			//
+			// ANSWER(manuel, 2023-06-22) I had to modify the QUeryParseStep and FormParseStep to actually
+			// use the default value from the ParameterDefinition only if the value hadn't been set yet,
+			// which makes sense.
 
 			parserOptions := []parser.ParserOption{}
 

--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -390,17 +390,6 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 				datatables.WithJSRendering(),
 			)
 
-			// TODO(manuel, 2023-05-25) We can't currently override defaults, since they are parsed up front.
-			// For that we would need https://github.com/go-go-golems/glazed/issues/239
-			// So for now, we only deal with overrides.
-			//
-			// ANSWER(manuel, 2023-06-22) Defaults should actually work by prepending them to the parsers,
-			// so that they fill the initial value. Not fully sure yet, let's give it a try actually.
-			//
-			// ANSWER(manuel, 2023-06-22) I had to modify the QUeryParseStep and FormParseStep to actually
-			// use the default value from the ParameterDefinition only if the value hadn't been set yet,
-			// which makes sense.
-
 			parserOptions := []parser.ParserOption{}
 
 			// TODO(manuel, 2023-06-21) This needs to be handled for each backend, not just the HTML one

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -75,6 +75,15 @@ func expandPath(path string) string {
 	return path
 }
 
+// TemplateLookupConfig is used to configured a directory based template lookup.
+type TemplateLookupConfig struct {
+	// Directories is a list of directories that will be searched for templates.
+	Directories []string `yaml:"directories,omitempty"`
+	// Patterns is a list of glob patterns that will be used to match files in the directories.
+	// If the list is empty, the default of **/*.tmpl.md and **/*.tmpl.html will be used
+	Patterns []string `yaml:"patterns,omitempty"`
+}
+
 // TODO(manuel, 2023-06-20) We should probably allow for environment values to be passed as data as well
 
 type CommandDir struct {
@@ -88,6 +97,8 @@ type CommandDir struct {
 	// so that we can bundle the embedded templates and override them with external ones, as well
 	// as merge together multiple datatables renderers.
 	TemplateDirectory string `yaml:"templateDirectory,omitempty"`
+
+	TemplateLookup *TemplateLookupConfig `yaml:"templateLookup,omitempty"`
 
 	TemplateName      string `yaml:"templateName,omitempty"`
 	IndexTemplateName string `yaml:"indexTemplateName,omitempty"`

--- a/pkg/handlers/config/config.go
+++ b/pkg/handlers/config/config.go
@@ -83,10 +83,12 @@ type CommandDir struct {
 
 	// TODO(manuel, 2023-06-21) Unify support to override the default renderer for individual routes
 	// See https://github.com/go-go-golems/parka/issues/55
+	//
 	// We should probably make it possible to pass multiple template directories for the renderer options
 	// so that we can bundle the embedded templates and override them with external ones, as well
 	// as merge together multiple datatables renderers.
 	TemplateDirectory string `yaml:"templateDirectory,omitempty"`
+
 	TemplateName      string `yaml:"templateName,omitempty"`
 	IndexTemplateName string `yaml:"indexTemplateName,omitempty"`
 

--- a/pkg/handlers/config/parse.go
+++ b/pkg/handlers/config/parse.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"os"
+)
+
+// evaluateEnv takes a node which can be either a string, or a map with a key `env` and a string value.
+// If the node is a string, it is returned as is.
+// If the node is a map, it is evaluated recursively. If the map has a single key named `_env`, the entire
+// map is replaced with the environment value corresponding to `_env`.
+// If it is a list, it is evaluated recursively.
+func evaluateEnv(node interface{}) (interface{}, error) {
+	switch value := node.(type) {
+	case map[string]interface{}:
+		if len(value) == 1 && value["_env"] != nil {
+			if envVar, ok := value["_env"]; ok {
+				envVal, ok := envVar.(string)
+				if !ok {
+					return nil, fmt.Errorf("'_env' key must have a string value")
+				}
+				return os.Getenv(envVal), nil
+			}
+		}
+
+		evaluated := make(map[string]interface{}, len(value))
+		for k, v := range value {
+			evalVal, err := evaluateEnv(v)
+			if err != nil {
+				return nil, err
+			}
+			evaluated[k] = evalVal
+		}
+		return evaluated, nil
+	case []interface{}:
+		evaluated := make([]interface{}, len(value))
+		for i, v := range value {
+			evalVal, err := evaluateEnv(v)
+			if err != nil {
+				return nil, err
+			}
+			evaluated[i] = evalVal
+		}
+		return evaluated, nil
+	default:
+		return value, nil
+	}
+}
+
+// evaluateLayerParams goes over the layer params and evaluates the environment variables.
+func evaluateLayerParams(params *LayerParams) (*LayerParams, error) {
+	ret := &LayerParams{}
+	evaluatedLayers, err := evaluateEnv(params.Layers)
+	if err != nil {
+		return nil, err
+	}
+	ret.Layers = evaluatedLayers.(map[string]map[string]interface{})
+
+	evaluatedFlags, err := evaluateEnv(params.Flags)
+	if err != nil {
+		return nil, err
+	}
+	ret.Flags = evaluatedFlags.(map[string]interface{})
+
+	evaluatedArguments, err := evaluateEnv(params.Arguments)
+	if err != nil {
+		return nil, err
+	}
+	ret.Arguments = evaluatedArguments.(map[string]interface{})
+
+	return ret, nil
+}

--- a/pkg/handlers/config/parse_test.go
+++ b/pkg/handlers/config/parse_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestEvaluateEnvSimpleString(t *testing.T) {
+	node := "test"
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, "test", evaluated)
+}
+
+func TestEvaluateEnvSimpleMap(t *testing.T) {
+	node := map[string]interface{}{
+		"test": "test",
+		"foo":  "bar",
+	}
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"test": "test",
+		"foo":  "bar",
+	}, evaluated)
+}
+
+func TestEvaluateEnvNestedMap(t *testing.T) {
+	node := map[string]interface{}{
+		"test": "test",
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"test": "test",
+		"foo": map[string]interface{}{
+			"bar": "baz",
+		},
+	}, evaluated)
+}
+
+func TestEvaluateEnvSimpleStringList(t *testing.T) {
+	node := []interface{}{
+		"test",
+		"foo",
+	}
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, []interface{}{
+		"test",
+		"foo",
+	}, evaluated)
+}
+
+func TestEvaluateEnvString(t *testing.T) {
+	node := map[string]interface{}{
+		"_env": "VARIABLE",
+	}
+	err := os.Setenv("VARIABLE", "test")
+	require.Nil(t, err)
+
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, "test", evaluated)
+}
+
+func TestEvaluateEnvMap(t *testing.T) {
+	node := map[string]interface{}{
+		"test": map[string]interface{}{
+			"_env": "VARIABLE",
+		},
+		"foo": map[string]interface{}{
+			"_env": "VARIABLE2",
+		},
+		"bar": "baz",
+	}
+	err := os.Setenv("VARIABLE", "test")
+	require.Nil(t, err)
+	err = os.Setenv("VARIABLE2", "test2")
+	require.Nil(t, err)
+
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"test": "test",
+		"foo":  "test2",
+		"bar":  "baz",
+	}, evaluated)
+}
+
+func TestEvaluateEnvStringList(t *testing.T) {
+	node := []interface{}{
+		map[string]interface{}{
+			"_env": "VARIABLE",
+		},
+		map[string]interface{}{
+			"_env": "VARIABLE2",
+		},
+		"bar",
+	}
+	err := os.Setenv("VARIABLE", "test")
+	require.Nil(t, err)
+	err = os.Setenv("VARIABLE2", "test2")
+	require.Nil(t, err)
+
+	evaluated, err := evaluateEnv(node)
+	require.Nil(t, err)
+	assert.Equal(t, []interface{}{
+		"test",
+		"test2",
+		"bar",
+	}, evaluated)
+}

--- a/pkg/render/datatables/datatables.go
+++ b/pkg/render/datatables/datatables.go
@@ -259,7 +259,11 @@ func NewDataTablesCreateOutputProcessorFunc(
 		}
 		options_ = append(options_, options...)
 
-		of := NewDataTablesOutputFormatter(t, gp.OutputFormatter().(*table.OutputFormatter), options_...)
+		of := NewDataTablesOutputFormatter(
+			t,
+			gp.OutputFormatter().(*table.OutputFormatter),
+			options_...,
+		)
 
 		gp2 := processor.NewGlazeProcessor(of)
 

--- a/pkg/render/datatables/datatables.go
+++ b/pkg/render/datatables/datatables.go
@@ -146,13 +146,6 @@ func WithUseDataTables() DataTablesOutputFormatterOption {
 //go:embed templates/*
 var templateFS embed.FS
 
-func NewDataTablesHTMLTemplateCreateProcessorFunc(
-	options ...render.HTMLTemplateOutputFormatterOption,
-) (glazed.CreateProcessorFunc, error) {
-	l := NewDataTablesLookupTemplate()
-	return render.NewHTMLTemplateLookupCreateProcessorFunc(l, "data-tables.tmpl.html", options...), nil
-}
-
 func NewDataTablesLookupTemplate() *render.LookupTemplateFromFS {
 	l := render.NewLookupTemplateFromFS(
 		render.WithFS(templateFS),

--- a/pkg/render/datatables/templates/data-tables.tmpl.html
+++ b/pkg/render/datatables/templates/data-tables.tmpl.html
@@ -73,6 +73,7 @@
 {{ end }}
 
 <div class="container">
+    <p><a href="{{.BasePath}}/sqleton">Top</a></p>
     <h1>{{.Command.Name}}</h1>
     <p>{{.Command.Short}}</p>
 

--- a/pkg/render/html.go
+++ b/pkg/render/html.go
@@ -98,16 +98,13 @@ func NewHTMLTemplateLookupCreateProcessorFunc(
 ) glazed.CreateProcessorFunc {
 	return func(c *gin.Context, pc *glazed.CommandContext) (
 		processor.Processor,
-		string, // content type
 		error,
 	) {
-		contextType := "text/html"
-
 		// Lookup template on every request, not up front. That way, templates can be reloaded without recreating the gin
 		// server.
 		t, err := lookup.Lookup(templateName)
 		if err != nil {
-			return nil, contextType, err
+			return nil, err
 		}
 
 		// Here, we use the parsed layer to configure the glazed middlewares.
@@ -130,19 +127,19 @@ func NewHTMLTemplateLookupCreateProcessorFunc(
 		}
 
 		if err != nil {
-			return nil, contextType, err
+			return nil, err
 		}
 
 		layout_, err := layout.ComputeLayout(pc)
 		if err != nil {
-			return nil, contextType, err
+			return nil, err
 		}
 
 		description := pc.Cmd.Description()
 
 		longHTML, err := RenderMarkdownToHTML(description.Long)
 		if err != nil {
-			return nil, contextType, err
+			return nil, err
 		}
 
 		options_ := []HTMLTemplateOutputFormatterOption{
@@ -158,6 +155,6 @@ func NewHTMLTemplateLookupCreateProcessorFunc(
 		of := NewHTMLTemplateOutputFormatter(t, gp.OutputFormatter().(*table.OutputFormatter), options_...)
 		gp2 := processor.NewGlazeProcessor(of)
 
-		return gp2, contextType, nil
+		return gp2, nil
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,6 +92,21 @@ func WithDefaultRenderer(r *render.Renderer) ServerOption {
 	}
 }
 
+func GetDefaultParkaTemplateLookup() (render.TemplateLookup, error) {
+	// this should be overloaded too
+	parkaLookup := render.NewLookupTemplateFromFS(
+		render.WithFS(templateFS),
+		render.WithBaseDir("web/src/templates"),
+		render.WithPatterns("**/*.tmpl.*"),
+	)
+	err := parkaLookup.Reload()
+	if err != nil {
+		return nil, err
+	}
+
+	return parkaLookup, nil
+}
+
 // GetDefaultParkaRendererOptions will return the default options for the parka renderer.
 // This includes looking up templates from the embedded templateFS to provide support for
 // markdown rendering with tailwind. This includes css files.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -224,7 +224,7 @@ func (s *Server) HandleSimpleQueryCommand(
 ) gin.HandlerFunc {
 	opts := glazed.NewHandleOptions(options)
 	opts.Handlers = append(opts.Handlers,
-		glazed.NewCommandHandlerFunc(cmd,
+		glazed.NewParserCommandHandlerFunc(cmd,
 			glazed.NewCommandQueryParser(cmd, opts.ParserOptions...)),
 	)
 	return glazed.GinHandleGlazedCommand(cmd, opts)
@@ -238,7 +238,7 @@ func (s *Server) HandleSimpleQueryOutputFileCommand(
 ) gin.HandlerFunc {
 	opts := glazed.NewHandleOptions(options)
 	opts.Handlers = append(opts.Handlers,
-		glazed.NewCommandHandlerFunc(cmd, glazed.NewCommandQueryParser(cmd, opts.ParserOptions...)),
+		glazed.NewParserCommandHandlerFunc(cmd, glazed.NewCommandQueryParser(cmd, opts.ParserOptions...)),
 	)
 	return glazed.GinHandleGlazedCommandWithOutputFile(cmd, outputFile, fileName, opts)
 }
@@ -254,7 +254,7 @@ func (s *Server) HandleSimpleFormCommand(
 		option(opts)
 	}
 	opts.Handlers = append(opts.Handlers,
-		glazed.NewCommandHandlerFunc(cmd, glazed.NewCommandFormParser(cmd, opts.ParserOptions...)),
+		glazed.NewParserCommandHandlerFunc(cmd, glazed.NewCommandFormParser(cmd, opts.ParserOptions...)),
 	)
 	return glazed.GinHandleGlazedCommand(cmd, opts)
 }


### PR DESCRIPTION
This adds support for the following CommandDirectory options in the config file:
- Overrides
- Defaults
- TemplateLookup
- IncludeDefaultRepositories
- AdditionalData

In the process of doing so, the ParserFunc API got updated to be a more traditional ParseStep 
struct based API. This makes it easier to track what is going on. 

Furthermore, alias defaults are now handled correctly in the NewParseStateFromCommand.

ContentType now comes from the glazed processor, there is thus no need to do some internal
spelunking as we did before to compute the right ContentType.

- :sparkles: Parse overrides and defaults and evaluate environment variables
- :umbrella: Add unit test for env expansion
- :tractor: :art: Start refactoring the parser API to be more legible
- :art: Refactor the parser functions to deal with a proper object
- :art: Add option to set override layer defaults
- :sparkles: Handle Overrides and Defaults in CommandDir
- :pencil: Update ANSWER to a question about setting defaults in command-dir
- :pencil: Remove answered TODO entry
- :sparkles: Add support for AdditionalData
- :ambulance: :sparkles: Support TemplateLookup config and default repositories
- :art: Streamline handling of ContentType now that the glazed.OutputFormatter provides it
- :pencil: Remove ANSWERed TODO entries
- :art: Add a top link to the BasePath to the data-tables template
- :pencil: :art: Tiny cleanup of comments and removal of unused functions
- :ambulance: Fix query_test after the numerous parser API changes
- :art: :arrow_up: We do now load viper to get the list of default  repositories
- :sparkles: Support aliases and clean up NewParserCommandHandlerFunc a bit
- :arrow_up: Bump glazed
