### PR TITLE
:sparkles: Add support for display command metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.37.5
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-go-golems/clay v0.0.24
-	github.com/go-go-golems/glazed v0.4.15
+	github.com/go-go-golems/clay v0.0.25
+	github.com/go-go-golems/glazed v0.4.16
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.37.5
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-go-golems/clay v0.0.23
-	github.com/go-go-golems/glazed v0.4.12
+	github.com/go-go-golems/clay v0.0.24
+	github.com/go-go-golems/glazed v0.4.15
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -137,10 +137,10 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/clay v0.0.23 h1:VJn58b1ZrR87DyKKcoi9eVHeDbfA0kg0EsceFIfgqLA=
-github.com/go-go-golems/clay v0.0.23/go.mod h1:tn4ZWCqBESPOrag12d2yYakqGwriiwrqbn0kP0PuWNw=
-github.com/go-go-golems/glazed v0.4.12 h1:ijUx/yqOg9PFIBU+a4id6EBKTRMN7QzDd166mjZMXus=
-github.com/go-go-golems/glazed v0.4.12/go.mod h1:ORRe+8ZW7S3OTd09QuDhDmDXK1QZBfmfIZUIaoEYqFU=
+github.com/go-go-golems/clay v0.0.24 h1:J5at0fFs5Gf7cVgYVofsil9P8VKYINEBSnHD+GECRWY=
+github.com/go-go-golems/clay v0.0.24/go.mod h1:BYKwQnbN76Qgg9WdX2N4gw1bU2FlMa4UhH89zd4W6vY=
+github.com/go-go-golems/glazed v0.4.15 h1:6gEogwfcX/xcueQ5EVd/tsY6HGZb4NNdAY1EYuoZE9s=
+github.com/go-go-golems/glazed v0.4.15/go.mod h1:ORRe+8ZW7S3OTd09QuDhDmDXK1QZBfmfIZUIaoEYqFU=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/go.sum
+++ b/go.sum
@@ -137,10 +137,10 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/clay v0.0.24 h1:J5at0fFs5Gf7cVgYVofsil9P8VKYINEBSnHD+GECRWY=
-github.com/go-go-golems/clay v0.0.24/go.mod h1:BYKwQnbN76Qgg9WdX2N4gw1bU2FlMa4UhH89zd4W6vY=
-github.com/go-go-golems/glazed v0.4.15 h1:6gEogwfcX/xcueQ5EVd/tsY6HGZb4NNdAY1EYuoZE9s=
-github.com/go-go-golems/glazed v0.4.15/go.mod h1:ORRe+8ZW7S3OTd09QuDhDmDXK1QZBfmfIZUIaoEYqFU=
+github.com/go-go-golems/clay v0.0.25 h1:KrZ5luxWRDIvt78dugTGdog5NWii201fCgfNgQMIN/k=
+github.com/go-go-golems/clay v0.0.25/go.mod h1:KX8IIKGpt9FvbwgcEBVOZfPB22LcdjRhVpjk8sB0SBs=
+github.com/go-go-golems/glazed v0.4.16 h1:cWwteFI8XcKgmqZFyjJhXpstgXmhfkC0it3hTUX6OcU=
+github.com/go-go-golems/glazed v0.4.16/go.mod h1:ORRe+8ZW7S3OTd09QuDhDmDXK1QZBfmfIZUIaoEYqFU=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/glazed/handlers/datatables/templates/data-tables.tmpl.html
+++ b/pkg/glazed/handlers/datatables/templates/data-tables.tmpl.html
@@ -157,11 +157,20 @@
     const jsData = [{{ range $b := .JSStream}}{{$b}},{{end}}];
     {{else }}const jsData = null;
     {{ end }}
+
     function getQueryString() {
         const form = document.getElementById('form');
         const formData = new FormData(form);
 
         const queryString = new URLSearchParams();
+
+        // Iterate over form elements
+        for (let element of form.elements) {
+            // Check if the element is an unchecked checkbox
+            if (element.type === 'checkbox' && !element.checked) {
+                queryString.append(element.name, 'false');
+            }
+        }
 
         formData.forEach((value, key) => {
             if (value) {

--- a/pkg/glazed/handlers/datatables/templates/data-tables.tmpl.html
+++ b/pkg/glazed/handlers/datatables/templates/data-tables.tmpl.html
@@ -102,6 +102,15 @@
     <div>{{.LongDescription }}</div>
     {{ end }}
 
+    {{ if .CommandMetadata }}
+    <details>
+        <summary>Command Metadata</summary>
+        {{ range $key, $value := .CommandMetadata }}
+        <p><strong>{{$key}}:</strong> <pre>{{$value}}</pre></p>
+        {{ end }}
+    </details>
+    {{ end }}
+
     <form id="form" action="{{.Command.Name}}" method="get">
         <fieldset>
             {{range $section := .Layout.Sections}}


### PR DESCRIPTION
This pull request introduces a significant enhancement to our DataTables component. The primary goal of these changes is to provide a mechanism for displaying command metadata, thereby offering more context and information to users.

Key changes include:

- Addition of a `CommandMetadata` field in the `DataTables` struct.
- Creation of a `NewDataTables()` constructor function for proper initialization of `DataTables` instances.
- Modification of `NewQueryHandler` function and `Handle` method of `QueryHandler` struct to accommodate the new `CommandMetadata` field.
- Refactoring of `CreateDataTablesHandler` function to utilize the new constructor.
- Update to the `data-tables.tmpl.html` template to display command metadata when available.

Closes https://github.com/go-go-golems/sqleton/issues/172

