### PR TITLE
Corrected Path Trimming in Download Handlers

### DIFF
--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -298,7 +298,7 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 
 	server.Router.GET(path+"/download/*path", func(c *gin.Context) {
 		path_ := c.Param("path")
-		path_ = strings.TrimPrefix(path_, path+"/")
+		path_ = strings.TrimPrefix(path_, "/")
 		index := strings.LastIndex(path_, "/")
 		if index == -1 {
 			c.JSON(500, gin.H{"error": "could not find file name"})

--- a/pkg/handlers/command/command.go
+++ b/pkg/handlers/command/command.go
@@ -271,7 +271,7 @@ func (ch *CommandHandler) Serve(server *parka.Server, path string) error {
 	})
 	server.Router.GET(path+"/download/*path", func(c *gin.Context) {
 		path_ := c.Param("path")
-		path_ = strings.TrimPrefix(path_, path+"/")
+		path_ = strings.TrimPrefix(path_, "/")
 		index := strings.LastIndex(path_, "/")
 		if index == -1 {
 			c.JSON(500, gin.H{"error": "could not find file name"})


### PR DESCRIPTION
This pull request addresses an issue with the download handlers in both the
`CommandDirHandler` and `CommandHandler` classes. The changes specifically
target the way paths are trimmed when handling download requests.

- In `command-dir.go` and `command.go`, the `strings.TrimPrefix` function was
  previously removing the entire path prefix, including the path itself. This
  has been corrected to only remove the leading slash ("/"), ensuring the
  correct file path is used for download requests.

