### PR TITLE
Standardize command loader interface across the codebase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.37.5
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-go-golems/clay v0.0.34
-	github.com/go-go-golems/glazed v0.4.34
+	github.com/go-go-golems/clay v0.0.35
+	github.com/go-go-golems/glazed v0.4.35
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.30.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -140,10 +140,10 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/clay v0.0.34 h1:8V2mYgRtYgOMerILaLjuSoGtQGbhyBi/o9+Wa/J/w4Y=
-github.com/go-go-golems/clay v0.0.34/go.mod h1:OXpn0dhsnQWnbEBVTEvoqezkdDHW/KA4H4opFwB1vxE=
-github.com/go-go-golems/glazed v0.4.34 h1:QEvfpYoRHiLBMnHkqVrZJs9+e1rHWKPTPu1PTbYWu1c=
-github.com/go-go-golems/glazed v0.4.34/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
+github.com/go-go-golems/clay v0.0.35 h1:/hMbLpQNhPS3mPy9PQ1dkHsu040/2l1YzZZY1x2+/XI=
+github.com/go-go-golems/clay v0.0.35/go.mod h1:CzCWwaHTPxr34Y2dETur0KOxTDz1KFK0fgfZFmo/7gU=
+github.com/go-go-golems/glazed v0.4.35 h1:ndRHgBgOqp6VuBVzKHiT/mtN/eZ+9bz9q1C8UPM8l0g=
+github.com/go-go-golems/glazed v0.4.35/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/handlers/command/command.go
+++ b/pkg/handlers/command/command.go
@@ -121,7 +121,7 @@ func NewCommandHandler(
 
 func NewCommandHandlerFromConfig(
 	config_ *config.Command,
-	loader loaders.FSCommandLoader,
+	loader loaders.CommandLoader,
 	options ...CommandHandlerOption,
 ) (*CommandHandler, error) {
 	c := &CommandHandler{
@@ -142,7 +142,9 @@ func NewCommandHandlerFromConfig(
 		filePath = absPath + config_.File
 	}
 
-	cmds_, err := loader.LoadCommandsFromFS(os.DirFS("/"), filePath, []cmds.CommandDescriptionOption{}, []alias.Option{})
+	cmds_, err := loaders.LoadCommandsFromFS(
+		os.DirFS("/"), filePath,
+		loader, []cmds.CommandDescriptionOption{}, []alias.Option{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load commands from file")
 	}

--- a/pkg/handlers/command/command.go
+++ b/pkg/handlers/command/command.go
@@ -130,20 +130,13 @@ func NewCommandHandlerFromConfig(
 		OverridesAndDefaults: &config.OverridesAndDefaults{},
 	}
 
-	// get absolute path from config_.File
-	absPath, err := os.Getwd()
+	fs_, filePath, err := loaders.FileNameToFsFilePath(config_.File)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get current working directory")
-	}
-	var filePath string
-	if strings.HasPrefix(config_.File, "/") {
-		filePath = config_.File
-	} else {
-		filePath = absPath + config_.File
+		return nil, errors.Wrap(err, "failed to get absolute path")
 	}
 
 	cmds_, err := loaders.LoadCommandsFromFS(
-		os.DirFS("/"), filePath,
+		fs_, filePath,
 		loader, []cmds.CommandDescriptionOption{}, []alias.Option{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load commands from file")

--- a/pkg/handlers/config-file.go
+++ b/pkg/handlers/config-file.go
@@ -35,8 +35,7 @@ type RepositoryFactory func(dirs []string) (*fs.Repository, error)
 // like a reader loader that is able to get other loaders for side files too, maybe, or a map of strings or a map of readers
 
 func NewRepositoryFactoryFromReaderLoaders(
-	commandLoader loaders.ReaderCommandLoader,
-	fsLoader loaders.FSCommandLoader,
+	fsLoader loaders.CommandLoader,
 ) RepositoryFactory {
 	return func(dirs []string) (*fs.Repository, error) {
 		r := fs.NewRepository(
@@ -59,7 +58,6 @@ func NewRepositoryFactoryFromReaderLoaders(
 				// We don't need to recompute the func, since it fetches the command at runtime.
 				return nil
 			}),
-			fs.WithReaderCommandLoader(commandLoader),
 			fs.WithFSLoader(fsLoader),
 		)
 

--- a/pkg/handlers/template-dir/template-dir.go
+++ b/pkg/handlers/template-dir/template-dir.go
@@ -2,13 +2,12 @@ package template_dir
 
 import (
 	"fmt"
+	"github.com/go-go-golems/glazed/pkg/cmds/loaders"
 	"github.com/go-go-golems/parka/pkg/handlers/config"
 	"github.com/go-go-golems/parka/pkg/render"
 	"github.com/go-go-golems/parka/pkg/server"
 	"io/fs"
-	"os"
 	"path/filepath"
-	"strings"
 )
 
 // TODO(manuel, 2023-05-28) Add a proper Handler interface that also
@@ -62,16 +61,10 @@ func WithLocalDirectory(localPath string) TemplateDirHandlerOption {
 			if len(p) == 0 {
 				return fmt.Errorf("invalid local path: %s", localPath)
 			}
-			if p[0] == '/' {
-				handler.fs = os.DirFS("/")
-			} else {
-				handler.fs = os.DirFS(".")
+			handler.fs, handler.LocalDirectory, err = loaders.FileNameToFsFilePath(p)
+			if err != nil {
+				return err
 			}
-			// We strip the / prefix because once the FS is /, we need to match for "relative" paths within the FS.
-			// We can't just simplify the whole thing to be os.DirFS(localPath) because we also need to support
-			// embed.FS where we can't do the same path shenanigans, since the embed.FS files reflect the directory
-			// from which they were included, which we need to strip at runtime.
-			handler.LocalDirectory = strings.TrimPrefix(p, "/")
 		}
 
 		return nil


### PR DESCRIPTION
This pull request refactors the command loader interfaces to match glazed.

Changes include:
- Replaced `loaders.FSCommandLoader` with `loaders.CommandLoader` in
  `NewCommandHandlerFromConfig` to standardize the loader interface.
- Removed `ReaderCommandLoader` from `NewRepositoryFactoryFromReaderLoaders`,
  consolidating to a single `CommandLoader` interface.
- Use `loaders.FileNameToFsFilePath` to handle relative paths for fs.FS use.