### PR TITLE
Refactor handlers to use updated repository package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.37.5
 	github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2
 	github.com/gin-gonic/gin v1.9.0
-	github.com/go-go-golems/clay v0.1.0
-	github.com/go-go-golems/glazed v0.5.0
+	github.com/go-go-golems/clay v0.1.8
+	github.com/go-go-golems/glazed v0.5.7
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.30.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -140,10 +140,10 @@ github.com/gin-gonic/gin v1.9.0/go.mod h1:W1Me9+hsUSyj3CePGrd1/QrKJMSJ1Tu/0hFEH8
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/clay v0.1.0 h1:QxkIllWsmcBHDqqFQAu0qn02W5KQxIVSrEbAXYh4UWU=
-github.com/go-go-golems/clay v0.1.0/go.mod h1:HHxtmgDOjNrx7sObkqjDupUp7AKpqlxEwuBpdO/oiZY=
-github.com/go-go-golems/glazed v0.5.0 h1:QtAnQkGTmJz4kWw72TPEyowCqTvDM3JokvcyyQ960LA=
-github.com/go-go-golems/glazed v0.5.0/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
+github.com/go-go-golems/clay v0.1.8 h1:65cxzA2T9TxjtDKfKG+1a/HhB6G/XlK+wETDybUZaD0=
+github.com/go-go-golems/clay v0.1.8/go.mod h1:4DtxJs314X0tk2LT/ubIVX55k2hM8hMmmOwB5Zcd7NI=
+github.com/go-go-golems/glazed v0.5.7 h1:Papb53cZnb2kDezUHYGAEdy5wjO7VkcInBbm1xIZWM8=
+github.com/go-go-golems/glazed v0.5.7/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -3,7 +3,7 @@ package command_dir
 import (
 	"fmt"
 	"github.com/gin-gonic/gin"
-	"github.com/go-go-golems/clay/pkg/repositories/fs"
+	"github.com/go-go-golems/clay/pkg/repositories"
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/parka/pkg/glazed/handlers/datatables"
 	"github.com/go-go-golems/parka/pkg/glazed/handlers/json"
@@ -32,7 +32,7 @@ type CommandDirHandler struct {
 	TemplateLookup render.TemplateLookup
 
 	// Repository is the command repository that is exposed over HTTP through this handler.
-	Repository *fs.Repository
+	Repository *repositories.Repository
 
 	// AdditionalData is passed to the template being rendered.
 	AdditionalData map[string]interface{}
@@ -122,7 +122,7 @@ func WithDevMode(devMode bool) CommandDirHandlerOption {
 	}
 }
 
-func WithRepository(r *fs.Repository) CommandDirHandlerOption {
+func WithRepository(r *repositories.Repository) CommandDirHandlerOption {
 	return func(handler *CommandDirHandler) {
 		handler.Repository = r
 	}
@@ -323,7 +323,7 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 
 // getRepositoryCommand lookups a command in the given repository and return success as bool and the given command,
 // or sends an error code over HTTP using the gin.Context.
-func getRepositoryCommand(c *gin.Context, r *fs.Repository, commandPath string) (
+func getRepositoryCommand(c *gin.Context, r *repositories.Repository, commandPath string) (
 	cmds.Command,
 	bool,
 ) {

--- a/pkg/handlers/command-dir/command-dir.go
+++ b/pkg/handlers/command-dir/command-dir.go
@@ -3,7 +3,6 @@ package command_dir
 import (
 	"fmt"
 	"github.com/gin-gonic/gin"
-	"github.com/go-go-golems/clay/pkg/repositories"
 	"github.com/go-go-golems/clay/pkg/repositories/fs"
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/parka/pkg/glazed/handlers/datatables"
@@ -324,7 +323,7 @@ func (cd *CommandDirHandler) Serve(server *parka.Server, path string) error {
 
 // getRepositoryCommand lookups a command in the given repository and return success as bool and the given command,
 // or sends an error code over HTTP using the gin.Context.
-func getRepositoryCommand(c *gin.Context, r repositories.Repository, commandPath string) (
+func getRepositoryCommand(c *gin.Context, r *fs.Repository, commandPath string) (
 	cmds.Command,
 	bool,
 ) {

--- a/pkg/handlers/config-file.go
+++ b/pkg/handlers/config-file.go
@@ -3,9 +3,10 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"github.com/go-go-golems/clay/pkg/repositories/fs"
+	"github.com/go-go-golems/clay/pkg/repositories"
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/loaders"
+	"github.com/go-go-golems/glazed/pkg/help"
 	"github.com/go-go-golems/glazed/pkg/helpers/strings"
 	"github.com/go-go-golems/parka/pkg/handlers/command-dir"
 	"github.com/go-go-golems/parka/pkg/handlers/config"
@@ -28,7 +29,7 @@ import (
 
 // RepositoryFactory is a function that returns a repository given a list of directories.
 // This is used to provision the CommandDir handlers.
-type RepositoryFactory func(dirs []string) (*fs.Repository, error)
+type RepositoryFactory func(dirs []string) (*repositories.Repository, error)
 
 // TODO(manuel, 2023-12-13) This currently uses a ReaderCommandLoader which assumes that there is a command in a single file
 // THat's however not the case when loading fat commands (like in escuse-me), so we might need something
@@ -37,10 +38,10 @@ type RepositoryFactory func(dirs []string) (*fs.Repository, error)
 func NewRepositoryFactoryFromReaderLoaders(
 	fsLoader loaders.CommandLoader,
 ) RepositoryFactory {
-	return func(dirs []string) (*fs.Repository, error) {
-		r := fs.NewRepository(
-			fs.WithDirectories(dirs),
-			fs.WithUpdateCallback(func(cmd cmds.Command) error {
+	return func(dirs []string) (*repositories.Repository, error) {
+		r := repositories.NewRepository(
+			repositories.WithDirectories(dirs...),
+			repositories.WithUpdateCallback(func(cmd cmds.Command) error {
 				description := cmd.Description()
 				log.Info().Str("name", description.Name).
 					Str("source", description.Source).
@@ -48,7 +49,7 @@ func NewRepositoryFactoryFromReaderLoaders(
 				// TODO(manuel, 2023-04-19) This is where we would recompute the HandlerFunc used below in GET and POST
 				return nil
 			}),
-			fs.WithRemoveCallback(func(cmd cmds.Command) error {
+			repositories.WithRemoveCallback(func(cmd cmds.Command) error {
 				description := cmd.Description()
 				log.Info().Str("name", description.Name).
 					Str("source", description.Source).
@@ -58,10 +59,12 @@ func NewRepositoryFactoryFromReaderLoaders(
 				// We don't need to recompute the func, since it fetches the command at runtime.
 				return nil
 			}),
-			fs.WithFSLoader(fsLoader),
+			repositories.WithCommandLoader(fsLoader),
 		)
 
-		err := r.LoadCommands()
+		// TODO(manuel, 2024-01-18) Properly integrate help system into parka
+		helpSystem := help.NewHelpSystem()
+		err := r.LoadCommands(helpSystem)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error initializing commands: %s\n", err)
 			os.Exit(1)

--- a/pkg/handlers/config-file.go
+++ b/pkg/handlers/config-file.go
@@ -40,6 +40,7 @@ func NewRepositoryFactoryFromReaderLoaders(
 ) RepositoryFactory {
 	return func(dirs []string) (*repositories.Repository, error) {
 		r := repositories.NewRepository(
+			repositories.WithFS(os.DirFS(".")),
 			repositories.WithDirectories(dirs...),
 			repositories.WithUpdateCallback(func(cmd cmds.Command) error {
 				description := cmd.Description()


### PR DESCRIPTION
- Refactored `CommandDirHandler` to use the `repositories.Repository`
  interface instead of the `fs.Repository` which has been removed.
- Updated the `RepositoryFactory` type and its `NewRepositoryFactoryFromReaderLoaders`
  function to return a `repositories.Repository` instance.
