### PR TITLE
Add support for URL path prefixes with WithRootPath

### DIFF
--- a/cmd/parka/cmds/serve.go
+++ b/cmd/parka/cmds/serve.go
@@ -71,9 +71,9 @@ var ServeCmd = &cobra.Command{
 
 		// NOTE(manuel, 2023-05-26) This could also be done with a simple Command config file struct once
 		// implemented as part of sqleton serve
-		s.Router.GET("/api/example", json2.CreateJSONQueryHandler(NewExampleCommand()))
-		s.Router.GET("/example", datatables.CreateDataTablesHandler(NewExampleCommand(), "", "example"))
-		s.Router.GET("/download/example.csv", output_file.CreateGlazedFileHandler(NewExampleCommand(), "example.csv"))
+		s.Group.GET("/api/example", json2.CreateJSONQueryHandler(NewExampleCommand()))
+		s.Group.GET("/example", datatables.CreateDataTablesHandler(NewExampleCommand(), "", "example"))
+		s.Group.GET("/download/example.csv", output_file.CreateGlazedFileHandler(NewExampleCommand(), "example.csv"))
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/pkg/handlers/generic-command/generic.go
+++ b/pkg/handlers/generic-command/generic.go
@@ -180,20 +180,20 @@ func WithWhitelistedLayers(layers ...string) GenericCommandHandlerOption {
 func (gch *GenericCommandHandler) ServeSingleCommand(server *parka.Server, basePath string, command cmds.Command) error {
 	gch.BasePath = basePath
 
-	server.Router.GET(basePath+"/data", func(c echo.Context) error {
+	server.Group.GET(basePath+"/data", func(c echo.Context) error {
 		return gch.ServeData(c, command)
 	})
-	server.Router.GET(basePath+"/text", func(c echo.Context) error {
+	server.Group.GET(basePath+"/text", func(c echo.Context) error {
 		return gch.ServeText(c, command)
 	})
-	server.Router.GET(basePath+"/stream", func(c echo.Context) error {
+	server.Group.GET(basePath+"/stream", func(c echo.Context) error {
 		return gch.ServeStreaming(c, command)
 	})
-	server.Router.GET(basePath+"/download/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/download/*", func(c echo.Context) error {
 		return gch.ServeDownload(c, command)
 	})
 	// don't use a specific datatables path here
-	server.Router.GET(basePath, func(c echo.Context) error {
+	server.Group.GET(basePath, func(c echo.Context) error {
 		return gch.ServeDataTables(c, command, basePath+"/download")
 	})
 
@@ -204,7 +204,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 	basePath = strings.TrimSuffix(basePath, "/")
 	gch.BasePath = basePath
 
-	server.Router.GET(basePath+"/data/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/data/*", func(c echo.Context) error {
 		commandPath := c.Param("*")
 		commandPath = strings.TrimPrefix(commandPath, "/")
 		command, err := getRepositoryCommand(repository, commandPath)
@@ -219,7 +219,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 		return gch.ServeData(c, command)
 	})
 
-	server.Router.GET(basePath+"/text/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/text/*", func(c echo.Context) error {
 		commandPath := c.Param("*")
 		commandPath = strings.TrimPrefix(commandPath, "/")
 		command, err := getRepositoryCommand(repository, commandPath)
@@ -234,7 +234,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 		return gch.ServeText(c, command)
 	})
 
-	server.Router.GET(basePath+"/streaming/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/streaming/*", func(c echo.Context) error {
 		commandPath := c.Param("*")
 		commandPath = strings.TrimPrefix(commandPath, "/")
 		command, err := getRepositoryCommand(repository, commandPath)
@@ -249,7 +249,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 		return gch.ServeStreaming(c, command)
 	})
 
-	server.Router.GET(basePath+"/datatables/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/datatables/*", func(c echo.Context) error {
 		commandPath := c.Param("*")
 		commandPath = strings.TrimPrefix(commandPath, "/")
 
@@ -266,7 +266,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 		return gch.ServeDataTables(c, command, basePath+"/download/"+commandPath)
 	})
 
-	server.Router.GET(basePath+"/download/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/download/*", func(c echo.Context) error {
 		commandPath := c.Param("*")
 		commandPath = strings.TrimPrefix(commandPath, "/")
 		// strip file name from path
@@ -291,7 +291,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 		return gch.ServeDownload(c, command)
 	})
 
-	server.Router.GET(basePath+"/", func(c echo.Context) error {
+	server.Group.GET(basePath+"/", func(c echo.Context) error {
 		renderNode, ok := repository.GetRenderNode([]string{})
 		if !ok {
 			return errors.Errorf("command root not found")
@@ -323,7 +323,7 @@ func (gch *GenericCommandHandler) ServeRepository(server *parka.Server, basePath
 		return nil
 	})
 
-	server.Router.GET(basePath+"/commands/*", func(c echo.Context) error {
+	server.Group.GET(basePath+"/commands/*", func(c echo.Context) error {
 		path_ := c.Param("*")
 		path_ = strings.TrimPrefix(path_, "/")
 		path_ = strings.TrimSuffix(path_, "/")

--- a/pkg/handlers/static-dir/static.go
+++ b/pkg/handlers/static-dir/static.go
@@ -62,6 +62,6 @@ func (s *StaticDirHandler) Serve(server *server.Server, path string) error {
 	if s.localPath != "" {
 		fs_ = fs2.NewAddPrefixPathFS(s.fs, s.localPath)
 	}
-	server.Router.StaticFS(path, fs_)
+	server.Group.StaticFS(path, fs_)
 	return nil
 }

--- a/pkg/handlers/static-file/static-file.go
+++ b/pkg/handlers/static-file/static-file.go
@@ -56,6 +56,6 @@ func NewStaticFileHandlerFromConfig(shf *config.StaticFile, options ...StaticFil
 }
 
 func (s *StaticFileHandler) Serve(server *server.Server, path string) error {
-	server.Router.StaticFS(path, echo.MustSubFS(s.fs, s.localPath))
+	server.Group.StaticFS(path, echo.MustSubFS(s.fs, s.localPath))
 	return nil
 }

--- a/pkg/handlers/template-dir/template-dir.go
+++ b/pkg/handlers/template-dir/template-dir.go
@@ -130,6 +130,6 @@ func NewTemplateDirHandlerFromConfig(td *config.TemplateDir, options ...Template
 
 func (td *TemplateDirHandler) Serve(server *server.Server, path string) error {
 	path = strings.TrimSuffix(path, "/")
-	server.Router.GET(path+"/*", td.renderer.WithTemplateDirHandler(nil))
+	server.Group.GET(path+"/*", td.renderer.WithTemplateDirHandler(nil))
 	return nil
 }

--- a/pkg/handlers/template/template.go
+++ b/pkg/handlers/template/template.go
@@ -1,10 +1,11 @@
 package template
 
 import (
+	"io/fs"
+
 	"github.com/go-go-golems/parka/pkg/handlers/config"
 	"github.com/go-go-golems/parka/pkg/render"
 	"github.com/go-go-golems/parka/pkg/server"
-	"io/fs"
 )
 
 type TemplateHandler struct {
@@ -79,7 +80,7 @@ func NewTemplateHandlerFromConfig(t *config.Template, options ...TemplateHandler
 }
 
 func (t *TemplateHandler) Serve(server_ *server.Server, path string) error {
-	server_.Router.GET(path, t.renderer.WithTemplateHandler(t.TemplateFile, nil))
+	server_.Group.GET(path, t.renderer.WithTemplateHandler(t.TemplateFile, nil))
 
 	return nil
 }

--- a/pkg/server/logging.go
+++ b/pkg/server/logging.go
@@ -2,11 +2,12 @@ package server
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/pprof"
+
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"net/http"
-	"net/http/pprof"
 )
 
 type stackTracer interface {
@@ -66,6 +67,6 @@ func (s *Server) RegisterDebugRoutes() {
 	for route, handler := range handlers_ {
 		route_ := route
 		handler_ := handler
-		s.Router.GET(route_, echo.WrapHandler(handler_))
+		s.Group.GET(route_, echo.WrapHandler(handler_))
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,7 +29,9 @@ var distFS embed.FS
 // It is meant to be quite flexible, allowing you to add static paths and template lookups
 // that can provide different fs and template backends.
 type Server struct {
-	Router *echo.Echo
+	router   *echo.Echo
+	Group    *echo.Group
+	RootPath string
 
 	// TODO(manuel, 2023-06-05) This should become a standard Static handler to be added to the Routes
 	StaticPaths []utils_fs.StaticPath
@@ -76,6 +78,14 @@ func WithPort(port uint16) ServerOption {
 func WithAddress(address string) ServerOption {
 	return func(s *Server) error {
 		s.Address = address
+		return nil
+	}
+}
+
+// WithRootPath sets the URL root under which to mount all routes.
+func WithRootPath(root string) ServerOption {
+	return func(s *Server) error {
+		s.RootPath = root
 		return nil
 	}
 }
@@ -161,7 +171,7 @@ func WithDefaultParkaStaticPaths() ServerOption {
 
 func WithGzip() ServerOption {
 	return func(s *Server) error {
-		s.Router.Use(middleware.Gzip())
+		s.router.Use(middleware.Gzip())
 		return nil
 	}
 }
@@ -198,7 +208,7 @@ func NewServer(options ...ServerOption) (*Server, error) {
 	router.HTTPErrorHandler = CustomHTTPErrorHandler
 
 	s := &Server{
-		Router:      router,
+		router:      router,
 		StaticPaths: []utils_fs.StaticPath{},
 	}
 
@@ -209,27 +219,30 @@ func NewServer(options ...ServerOption) (*Server, error) {
 		}
 	}
 
+	// Mount all handlers and static paths under the configured root prefix
+	s.Group = s.router.Group(s.RootPath)
+
 	return s, nil
 }
 
 // Run will start the server and listen on the given address and port.
 func (s *Server) Run(ctx context.Context) error {
 	for _, path := range s.StaticPaths {
-		s.Router.StaticFS(path.UrlPath, path.FS)
+		s.Group.StaticFS(path.UrlPath, path.FS)
 	}
 
 	// match all remaining paths to the templates
 	if s.DefaultRenderer != nil {
 		// TODO(manuel, 2024-05-08) I don't think we even need the explicit index mapping
-		//s.Router.GET("/", s.DefaultRenderer.WithTemplateHandler("index", nil))
-		s.Router.GET("/*", s.DefaultRenderer.WithTemplateDirHandler(nil))
+		//s.Group.GET("/", s.DefaultRenderer.WithTemplateHandler("index", nil))
+		s.Group.GET("/*", s.DefaultRenderer.WithTemplateDirHandler(nil))
 	}
 
 	addr := fmt.Sprintf("%s:%d", s.Address, s.Port)
 
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           s.Router,
+		Handler:           s.router,
 		ReadHeaderTimeout: 20 * time.Second, // Add timeout to mitigate Slowloris attacks
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -225,6 +225,10 @@ func NewServer(options ...ServerOption) (*Server, error) {
 	return s, nil
 }
 
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.router.ServeHTTP(w, r)
+}
+
 // Run will start the server and listen on the given address and port.
 func (s *Server) Run(ctx context.Context) error {
 	for _, path := range s.StaticPaths {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -24,7 +24,7 @@ func TestRunGlazedCommand(t *testing.T) {
 
 	s.Group.GET("/test", handler)
 
-	server := httptest.NewServer(s.router)
+	server := httptest.NewServer(s)
 	defer server.Close()
 
 	t.Run("test-simple-command", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,30 +1,30 @@
-package server_test
+package server
 
 import (
 	"encoding/json"
-	json2 "github.com/go-go-golems/parka/pkg/glazed/handlers/json"
-	"github.com/go-go-golems/parka/pkg/server"
-	"github.com/go-go-golems/parka/pkg/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	json2 "github.com/go-go-golems/parka/pkg/glazed/handlers/json"
+	"github.com/go-go-golems/parka/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRunGlazedCommand(t *testing.T) {
 	tc, err := utils.NewTestGlazedCommand()
 	require.NoError(t, err)
 
-	s, err := server.NewServer()
+	s, err := NewServer()
 	require.NoError(t, err)
 
 	handler := json2.CreateJSONQueryHandler(tc)
 
-	s.Router.GET("/test", handler)
+	s.Group.GET("/test", handler)
 
-	server := httptest.NewServer(s.Router)
+	server := httptest.NewServer(s.router)
 	defer server.Close()
 
 	t.Run("test-simple-command", func(t *testing.T) {


### PR DESCRIPTION
This PR refactors the server structure to allow mounting all handlers under a
configurable root URL path. This enables deploying Parka applications in
subdirectories or behind path-based proxies.

Key changes:
- Add new `WithRootPath()` option to set a URL prefix for all routes
- Replace direct `Router` access with `Group` for all handlers
- Make the original router private while exposing a group-based interface
- Implement `ServeHTTP` method to make Server directly usable as an http.Handler

Example usage:
```go
// Mount all handlers under "/my-app" prefix
server, err := parka.NewServer(parka.WithRootPath("/my-app"))

// All routes are now prefixed automatically
server.Group.GET("/api/data", myHandler)  // accessible at /my-app/api/data
```

This change maintains backward compatibility while adding flexibility for
deployments where the application needs to be mounted at a specific URL path.